### PR TITLE
Configure service cloudbuilds

### DIFF
--- a/aggregator/cloudbuild.yaml
+++ b/aggregator/cloudbuild.yaml
@@ -22,4 +22,4 @@ steps:
         fi
 
 options:
-  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET
+  logging: CLOUD_LOGGING_ONLY

--- a/aggregator/cloudbuild.yaml
+++ b/aggregator/cloudbuild.yaml
@@ -20,3 +20,6 @@ steps:
         else
           exit 0
         fi
+
+options:
+  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -16,3 +16,6 @@ steps:
     entrypoint: 'npm'
     dir: ./
     args: ['run', 'eslint:ci']
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/patient-browser/cloudbuild.yaml
+++ b/patient-browser/cloudbuild.yaml
@@ -20,3 +20,6 @@ steps:
         else
           exit 0
         fi
+
+options:
+  logging: CLOUD_LOGGING_ONLY

--- a/synthesizer/cloudbuild.yaml
+++ b/synthesizer/cloudbuild.yaml
@@ -20,3 +20,6 @@ steps:
         else
           exit 0
         fi
+
+options:
+  logging: CLOUD_LOGGING_ONLY


### PR DESCRIPTION
TODO: 
  - [x] click ops a cloudbuild service account
  - [x] click ops the github repo connection (gen 1)
  - [x] click ops triggers for `/aggregator/cloudbuild.yaml`,  `/synthesizer/cloudbuild.yaml`, and  `/patient-browser/cloudbuild.yaml`
  - [x] add logging config option to cloudbuild files

Note: I've not set up a trigger for the root cloudbuild file, it's currently pointless. If we don't end up mostly using JS/TS in this project, then it and the other root level JS ecosystem configuration can be tossed.