### PR TITLE
Change `ReferenceDate` source in aggregator service logic

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -284,7 +284,7 @@ services:
       PT: on
       FHIR_URL: http://on-fhir:8080/fhir # in this case, resolved inside the container, with container networking
   on-aggregator: &aggregator-service
-    image: aggregator:1.1
+    image: aggregator:1.2
     tty: ${DOCKER_TTY:-true}
     restart: always
     build:


### PR DESCRIPTION
Currently, the aggregation logic includes a `ReferenceDate` field derived from the occurrence time of individual immunizations. Given that the synthetic data distributes random occurrence time in a broad range, and only generates 100 records, the resulting data tends to have a single count per `ReferenceDate`. The `MIN_COUNT_THRESHOLD` default of 1 would then filter the returned aggregated results down to an empty list.

In reality, there's a much higher chance that more than one immunization within an age/gender group is administered on any given day where immunizations occur, so we could tune the synthetic data generation to create more date groupings. Might still be worth doing, but I also believe that occurrence time should not be the source of `ReferenceDate`.

My expectation is that the IDVP dataset's current `ReferenceDate` fields are the information retrieval reference dates. This PR applies that assumption to the aggregator logic, which has the side effect of "fixing" the issue with the endpoint mostly returning a list filtered to nothing.