### PR TITLE
Manifests for federal aggregator service

### DIFF
--- a/k8s/bc/virtual-service.yaml
+++ b/k8s/bc/virtual-service.yaml
@@ -27,3 +27,12 @@ spec:
             host: hapi-fhir-svc.bc.svc.cluster.local
             port:
               number: 8080
+    - match:
+        - headers:
+            ":authority":
+              exact: "aggregator.bc.iidi.alpha.phac.gc.ca"
+      route:
+        - destination:
+            host: aggregator-service.bc.svc.cluster.local
+            port:
+              number: 80

--- a/k8s/federal/federator/deployment.yaml
+++ b/k8s/federal/federator/deployment.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: federator-deployment
+  namespace: "federal"
+  labels:
+    app: federator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: federator
+  template:
+    metadata:
+      labels:
+        app: federator
+    spec:
+      containers:
+      - name: federator
+        image: northamerica-northeast1-docker.pkg.dev/phx-01he5rx4wsv/paradire/iidi-federator:latest
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 3000
+        env:
+        - name: DEV_IS_LOCAL_ENV
+          value: "false"
+        - name: AGGREGATOR_URLS
+          value: "https://aggregator.on.iidi.alpha.phac.gc.ca,https://aggregator.bc.iidi.alpha.phac.gc.ca"
+        resources:
+          requests:
+            memory: "256Mi"
+            cpu: "200m"
+          limits:
+            memory: "1Gi"
+            cpu: "1"
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 15
+          timeoutSeconds: 3
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 3000
+          initialDelaySeconds: 30
+          periodSeconds: 20
+          timeoutSeconds: 3
+          failureThreshold: 3

--- a/k8s/federal/federator/kustomization.yaml
+++ b/k8s/federal/federator/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - deployment.yaml
+  - service.yaml

--- a/k8s/federal/federator/service.yaml
+++ b/k8s/federal/federator/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: federator-svc
+  namespace: "federal"
+  labels:
+    app: federator
+spec:
+  type: ClusterIP
+  ports:
+  - port: 80
+    targetPort: 3000
+    protocol: TCP
+  selector:
+    app: federator

--- a/k8s/federal/kustomization.yaml
+++ b/k8s/federal/kustomization.yaml
@@ -1,0 +1,7 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+  - virtual-service.yaml
+  - ./federator

--- a/k8s/federal/namespace.yaml
+++ b/k8s/federal/namespace.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: "federal"
+  annotations:
+    mesh.cloud.google.com/proxy: '{"managed": true}'
+  labels:
+    name: istio-system
+    istio.io/rev: asm-managed
+spec: {}
+status: {}

--- a/k8s/federal/virtual-service.yaml
+++ b/k8s/federal/virtual-service.yaml
@@ -1,0 +1,20 @@
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: federal-virtual-service
+  namespace: istio-ingress
+spec:
+  hosts:
+    - "*.federal.iidi.alpha.phac.gc.ca"
+  gateways:
+    - istio-ingress/mesh-gateway
+  http:
+    - match:
+        - headers:
+            ":authority":
+              exact: "federator.federal.iidi.alpha.phac.gc.ca"
+      route:
+        - destination:
+            host: federator-svc.federal.svc.cluster.local
+            port:
+              number: 80

--- a/k8s/istio-ingress/gw-certificate.yaml
+++ b/k8s/istio-ingress/gw-certificate.yaml
@@ -7,6 +7,7 @@ spec:
   dnsNames:
     - "*.bc.iidi.alpha.phac.gc.ca"
     - "*.on.iidi.alpha.phac.gc.ca"
+    - "*.federal.iidi.alpha.phac.gc.ca"
   issuerRef:
     kind: ClusterIssuer
     name: letsencrypt-production

--- a/k8s/istio-ingress/mesh-gateway.yaml
+++ b/k8s/istio-ingress/mesh-gateway.yaml
@@ -14,6 +14,7 @@ spec:
       hosts:
         - "*.bc.iidi.alpha.phac.gc.ca"
         - "*.on.iidi.alpha.phac.gc.ca"
+        - "*.federal.iidi.alpha.phac.gc.ca"
       tls:
         httpsRedirect: true
     - port:
@@ -23,6 +24,7 @@ spec:
       hosts:
         - "*.bc.iidi.alpha.phac.gc.ca"
         - "*.on.iidi.alpha.phac.gc.ca"
+        - "*.federal.iidi.alpha.phac.gc.ca"
       tls:
         mode: SIMPLE
         credentialName: tlskeys

--- a/k8s/on/virtual-service.yaml
+++ b/k8s/on/virtual-service.yaml
@@ -27,3 +27,12 @@ spec:
             host: hapi-fhir-svc.on.svc.cluster.local
             port:
               number: 8080
+    - match:
+        - headers:
+            ":authority":
+              exact: "aggregator.on.iidi.alpha.phac.gc.ca"
+      route:
+        - destination:
+            host: aggregator-service.on.svc.cluster.local
+            port:
+              number: 80


### PR DESCRIPTION
Added manifests for federator service. Closes #132 

Note: Made the provincial aggregator end points accessible from outside the cluster and to be used in the federator service, since they will be available for use from the individual PTs.

Aggregate end point: https://federator.federal.iidi.alpha.phac.gc.ca/aggregated-data