### PR TITLE
Update cloudbuilds for consistency, bash best practices, and image tag correctness

### DIFF
--- a/aggregator/cloudbuild.yaml
+++ b/aggregator/cloudbuild.yaml
@@ -1,23 +1,57 @@
 steps:
-  - id: build-and-push-if-main
-    name: 'gcr.io/cloud-builders/docker@sha256:4a320eb06b1a8f3abe1243b0aad20ad9d8455f1dbfc032a3d941340622494005'
+  - name: 'gcr.io/cloud-builders/docker'
+    id: generate-image-name
     entrypoint: 'bash'
     dir: aggregator
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" == "main" ]]
-        then
-          service_name="iidi-aggregator"
-          
-          image_name="northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service_name}"
-          latest_image_tag="${image_name}:latest"
-          unique_image_tag="${image_name}:${BRANCH_NAME}-${COMMIT_SHA:-unknown_sha}-$(date +%s)"
+        set -o errexit
+        set -o pipefail
+        set -o nounset
 
-          docker build -t "${latest_image_tag}" -t "${unique_image_tag}" -f ./Dockerfile .
+        service="iidi-aggregator"
 
-          docker push --all-tags "${image_name}"
+        branch="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+        short_sha="${COMMIT_SHA:-$(git rev-parse --short HEAD)}"
+        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service}:${branch}-${short_sha}-$(date +%s)" > /workspace/imagename
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: build-if-main
+    entrypoint: 'bash'
+    dir: aggregator
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Building Docker image: ${image}"
+          docker build -t "${image}" -f ./Dockerfile .
         else
+          echo "Skipping build: Not on 'main' branch"
+          exit 0
+        fi
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: push-if-main
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Pushing Docker image: ${image}"
+          docker push "${image}"
+        else
+          echo "Skipping push: Not on 'main' branch"
           exit 0
         fi
 

--- a/demo-portal/cloudbuild.yaml
+++ b/demo-portal/cloudbuild.yaml
@@ -7,9 +7,15 @@ steps:
     args:
       - '-c'
       - |
-        set -e
-        SHORT_SHA="${COMMIT_SHA:-$(git rev-parse --short HEAD)}"
-        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/demo-portal:main-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        service="demo-portal"
+
+        branch="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+        short_sha="${COMMIT_SHA:-$(git rev-parse --short HEAD)}"
+        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service}:${branch}-${short_sha}-$(date +%s)" > /workspace/imagename
 
   # Step 2: Build the Docker image if the branch is 'main'
   - name: 'gcr.io/cloud-builders/docker'
@@ -19,10 +25,14 @@ steps:
     args:
       - '-c'
       - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
         if [[ "$BRANCH_NAME" == "main" ]]; then
           image=$(cat /workspace/imagename)
-          echo "Building Docker image: $image"
-          docker build -t "$image" -f ./Dockerfile .
+          echo "Building Docker image: ${image}"
+          docker build -t "${image}" -f ./Dockerfile .
         else
           echo "Skipping build: Not on 'main' branch"
           exit 0
@@ -35,10 +45,14 @@ steps:
     args:
       - '-c'
       - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
         if [[ "$BRANCH_NAME" == "main" ]]; then
           image=$(cat /workspace/imagename)
-          echo "Pushing Docker image: $image"
-          docker push "$image"
+          echo "Pushing Docker image: ${image}"
+          docker push "${image}"
         else
           echo "Skipping push: Not on 'main' branch"
           exit 0

--- a/federator/cloudbuild.yaml
+++ b/federator/cloudbuild.yaml
@@ -17,25 +17,59 @@ steps:
     entrypoint: npm
     args: ['run', 'jest']
 
-  - id: build-and-push-if-main
-    name: 'gcr.io/cloud-builders/docker'
+  - name: 'gcr.io/cloud-builders/docker'
+    id: generate-image-name
     entrypoint: 'bash'
     dir: federator
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" == "main" ]]
-        then
-          service_name="iidi-federator"
-          
-          image_name="northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service_name}"
-          latest_image_tag="${image_name}:latest"
-          unique_image_tag="${image_name}:${BRANCH_NAME}-${COMMIT_SHA:-unknown_sha}-$(date +%s)"
+        set -o errexit
+        set -o pipefail
+        set -o nounset
 
-          docker build -t "${latest_image_tag}" -t "${unique_image_tag}" -f ./Dockerfile .
+        service="iidi-federator"
 
-          docker push --all-tags "${image_name}"
+        branch="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+        short_sha="${COMMIT_SHA:-$(git rev-parse --short HEAD)}"
+        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service}:${branch}-${short_sha}-$(date +%s)" > /workspace/imagename
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: build-if-main
+    entrypoint: 'bash'
+    dir: federator
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Building Docker image: ${image}"
+          docker build -t "${image}" -f ./Dockerfile .
         else
+          echo "Skipping build: Not on 'main' branch"
+          exit 0
+        fi
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: push-if-main
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Pushing Docker image: ${image}"
+          docker push "${image}"
+        else
+          echo "Skipping push: Not on 'main' branch"
           exit 0
         fi
 

--- a/patient-browser/cloudbuild.yaml
+++ b/patient-browser/cloudbuild.yaml
@@ -1,23 +1,57 @@
 steps:
-  - id: build-and-push-if-main
-    name: 'gcr.io/cloud-builders/docker@sha256:4a320eb06b1a8f3abe1243b0aad20ad9d8455f1dbfc032a3d941340622494005'
+  - name: 'gcr.io/cloud-builders/docker'
+    id: generate-image-name
     entrypoint: 'bash'
-    dir: patient-browser
+    dir: rshiny-dashboard
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" == "main" ]]
-        then
-          service_name="patient-browser-iidi"
-          
-          image_name="northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service_name}"
-          latest_image_tag="${image_name}:latest"
-          unique_image_tag="${image_name}:${BRANCH_NAME}-${COMMIT_SHA:-unknown_sha}-$(date +%s)"
+        set -o errexit
+        set -o pipefail
+        set -o nounset
 
-          docker build -t "${latest_image_tag}" -t "${unique_image_tag}" -f ./Dockerfile .
+        service="patient-browser-iidi"
 
-          docker push --all-tags "${image_name}"
+        branch="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+        short_sha="${COMMIT_SHA:-$(git rev-parse --short HEAD)}"
+        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service}:${branch}-${short_sha}-$(date +%s)" > /workspace/imagename
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: build-if-main
+    entrypoint: 'bash'
+    dir: rshiny-dashboard
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Building Docker image: ${image}"
+          docker build -t "${image}" -f ./Dockerfile .
         else
+          echo "Skipping build: Not on 'main' branch"
+          exit 0
+        fi
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: push-if-main
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Pushing Docker image: ${image}"
+          docker push "${image}"
+        else
+          echo "Skipping push: Not on 'main' branch"
           exit 0
         fi
 

--- a/rshiny-dashboard/cloudbuild.yaml
+++ b/rshiny-dashboard/cloudbuild.yaml
@@ -7,9 +7,15 @@ steps:
     args:
       - '-c'
       - |
-        set -e
-        SHORT_SHA="${COMMIT_SHA:-$(git rev-parse --short HEAD)}"
-        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/iidi-dashboard:main-$SHORT_SHA-$(date +%s)" > /workspace/imagename
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        service="iidi-dashboard"
+
+        branch="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+        short_sha="${COMMIT_SHA:-$(git rev-parse --short HEAD)}"
+        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service}:${branch}-${short_sha}-$(date +%s)" > /workspace/imagename
 
   # Step 2: Build the Docker image if the branch is 'main'
   - name: 'gcr.io/cloud-builders/docker'
@@ -19,10 +25,14 @@ steps:
     args:
       - '-c'
       - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
         if [[ "$BRANCH_NAME" == "main" ]]; then
           image=$(cat /workspace/imagename)
-          echo "Building Docker image: $image"
-          docker build -t "$image" -f ./Dockerfile .
+          echo "Building Docker image: ${image}"
+          docker build -t "${image}" -f ./Dockerfile .
         else
           echo "Skipping build: Not on 'main' branch"
           exit 0
@@ -35,10 +45,14 @@ steps:
     args:
       - '-c'
       - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
         if [[ "$BRANCH_NAME" == "main" ]]; then
           image=$(cat /workspace/imagename)
-          echo "Pushing Docker image: $image"
-          docker push "$image"
+          echo "Pushing Docker image: ${image}"
+          docker push "${image}"
         else
           echo "Skipping push: Not on 'main' branch"
           exit 0

--- a/synthesizer/cloudbuild.yaml
+++ b/synthesizer/cloudbuild.yaml
@@ -1,23 +1,57 @@
 steps:
-  - id: build-and-push-if-main
-    name: 'gcr.io/cloud-builders/docker@sha256:4a320eb06b1a8f3abe1243b0aad20ad9d8455f1dbfc032a3d941340622494005'
+  - name: 'gcr.io/cloud-builders/docker'
+    id: generate-image-name
     entrypoint: 'bash'
     dir: synthesizer
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" == "main" ]]
-        then
-          service_name="synthetic-data"
-          
-          image_name="northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service_name}"
-          latest_image_tag="${image_name}:latest"
-          unique_image_tag="${image_name}:${BRANCH_NAME}-${COMMIT_SHA:-unknown_sha}-$(date +%s)"
+        set -o errexit
+        set -o pipefail
+        set -o nounset
 
-          docker build -t "${latest_image_tag}" -t "${unique_image_tag}" -f ./Dockerfile .
+        service="synthetic-data"
 
-          docker push --all-tags "${image_name}"
+        branch="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+        short_sha="${COMMIT_SHA:-$(git rev-parse --short HEAD)}"
+        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service}:${branch}-${short_sha}-$(date +%s)" > /workspace/imagename
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: build-if-main
+    entrypoint: 'bash'
+    dir: synthesizer
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Building Docker image: ${image}"
+          docker build -t "${image}" -f ./Dockerfile .
         else
+          echo "Skipping build: Not on 'main' branch"
+          exit 0
+        fi
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: push-if-main
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Pushing Docker image: ${image}"
+          docker push "${image}"
+        else
+          echo "Skipping push: Not on 'main' branch"
           exit 0
         fi
 

--- a/transfer-inbound/cloudbuild.yaml
+++ b/transfer-inbound/cloudbuild.yaml
@@ -17,25 +17,59 @@ steps:
     entrypoint: npm
     args: ['run', 'jest']
 
-  - id: build-and-push-if-main
-    name: 'gcr.io/cloud-builders/docker'
+  - name: 'gcr.io/cloud-builders/docker'
+    id: generate-image-name
     entrypoint: 'bash'
     dir: transfer-inbound
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" == "main" ]]
-        then
-          service_name="iidi-transfer-inbound"
-          
-          image_name="northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service_name}"
-          latest_image_tag="${image_name}:latest"
-          unique_image_tag="${image_name}:${BRANCH_NAME}-${COMMIT_SHA:-unknown_sha}-$(date +%s)"
+        set -o errexit
+        set -o pipefail
+        set -o nounset
 
-          docker build -t "${latest_image_tag}" -t "${unique_image_tag}" -f ./Dockerfile .
+        service="iidi-transfer-inbound"
 
-          docker push --all-tags "${image_name}"
+        branch="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+        short_sha="${COMMIT_SHA:-$(git rev-parse --short HEAD)}"
+        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service}:${branch}-${short_sha}-$(date +%s)" > /workspace/imagename
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: build-if-main
+    entrypoint: 'bash'
+    dir: transfer-inbound
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Building Docker image: ${image}"
+          docker build -t "${image}" -f ./Dockerfile .
         else
+          echo "Skipping build: Not on 'main' branch"
+          exit 0
+        fi
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: push-if-main
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Pushing Docker image: ${image}"
+          docker push "${image}"
+        else
+          echo "Skipping push: Not on 'main' branch"
           exit 0
         fi
 

--- a/transfer-outbound/cloudbuild.yaml
+++ b/transfer-outbound/cloudbuild.yaml
@@ -17,25 +17,59 @@ steps:
     entrypoint: npm
     args: ['run', 'jest']
 
-  - id: build-and-push-if-main
-    name: 'gcr.io/cloud-builders/docker'
+  - name: 'gcr.io/cloud-builders/docker'
+    id: generate-image-name
     entrypoint: 'bash'
     dir: transfer-outbound
     args:
       - '-c'
       - |
-        if [[ "$BRANCH_NAME" == "main" ]]
-        then
-          service_name="iidi-transfer-outbound"
-          
-          image_name="northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service_name}"
-          latest_image_tag="${image_name}:latest"
-          unique_image_tag="${image_name}:${BRANCH_NAME}-${COMMIT_SHA:-unknown_sha}-$(date +%s)"
+        set -o errexit
+        set -o pipefail
+        set -o nounset
 
-          docker build -t "${latest_image_tag}" -t "${unique_image_tag}" -f ./Dockerfile .
+        service="iidi-transfer-outbound"
 
-          docker push --all-tags "${image_name}"
+        branch="${BRANCH_NAME:-$(git rev-parse --abbrev-ref HEAD)}"
+        short_sha="${COMMIT_SHA:-$(git rev-parse --short HEAD)}"
+        echo "northamerica-northeast1-docker.pkg.dev/${PROJECT_ID}/paradire/${service}:${branch}-${short_sha}-$(date +%s)" > /workspace/imagename
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: build-if-main
+    entrypoint: 'bash'
+    dir: transfer-outbound
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Building Docker image: ${image}"
+          docker build -t "${image}" -f ./Dockerfile .
         else
+          echo "Skipping build: Not on 'main' branch"
+          exit 0
+        fi
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: push-if-main
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Pushing Docker image: ${image}"
+          docker push "${image}"
+        else
+          echo "Skipping push: Not on 'main' branch"
           exit 0
         fi
 


### PR DESCRIPTION
Follow-up:
  - [ ] click ops all cloudbuild triggers to run on all branches