### PR TITLE
Revert aggregator ReferenceDate single source of truth, fix for aggregators in local dev env

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,17 @@ Before setting up the development environment, ensure the following dependencies
   - or manually run the `predev` and `dev` commands as defined in the root `package.json`
 - Wait for docker-compose services to finish spinning up
 - Visit http://localhost:8080 for the "demo portal", which links through to the available services
+
+### IMPORTANT: working with the local docker-compose env
+
+It's important to note that the local docker images are cached by the `name:tag` pair set in each docker-compose service's `image` field. Images that copy in code/dependnecies at image build time need to have their tag incremented in the docker-compose file to ensure that up to date changes are captured! This is both a problem in dev (to refresh against local changes, you need to either increment the tag number or run `docker image rm name:tag --force` and then restart the docker-compose env) and for commited code between devs (assume other devs have cached builds of older version numbers, if you merge changes without bumping the tag then your changes may not be reflected in their local dev env).
+
+At the moment, this impacts
+
+- both synthesizers
+- both aggregators
+- both patient browsers
+- the r-shiny dashboard
+- the demo portal
+
+This does not impact any service using the `node-dev` image. The `node-dev` image mounts source files from the local dev machine and installs dependencies at run time. The `node-dev` services are always kept "live" against local repo state.

--- a/aggregator/aggregator.py
+++ b/aggregator/aggregator.py
@@ -102,7 +102,6 @@ def process_immunization_record(immunization):
         occurrence_year = occurrence_date[:4] if len(occurrence_date) >= 4 else "Unknown"
         
         return {
-            "ReferenceDate": datetime.now().strftime('%Y-%m-%d'),
             "OccurrenceYear": occurrence_year.strip(),
             "Jurisdiction": "BC" if "bc" in FHIR_URL else "ON",
             "Sex": patient.get("gender", "Unknown").capitalize(),
@@ -137,14 +136,14 @@ def aggregate_data():
     df["AgeGroup"] = df["AgeGroup"].str.strip()
     
     aggregated = df.groupby([
-        "ReferenceDate", "OccurrenceYear", "Jurisdiction", "Sex", "AgeGroup"
+        "OccurrenceYear", "Jurisdiction", "Sex", "AgeGroup"
     ], as_index=False).agg(
         DoseCount=("DoseCount", "sum"),
         Count=("DoseCount", "count")
     )
     
     aggregated = aggregated.sort_values(
-        by=["ReferenceDate", "OccurrenceYear", "AgeGroup", "Sex"], ascending=[True, True, True, True]
+        by=["OccurrenceYear", "AgeGroup", "Sex"], ascending=[True, True, True]
     )
     
     aggregated = aggregated[aggregated["Count"] > MIN_COUNT_THRESHOLD]
@@ -154,15 +153,26 @@ def aggregate_data():
 def get_aggregated_data():
     """API endpoint to return aggregated data."""
     global cached_data, last_aggregation_time
-    current_time = datetime.now().timestamp()
+
+    reference_date = datetime.now()
+    current_time = reference_date.timestamp()
     
     if cached_data and last_aggregation_time and (current_time - last_aggregation_time < AGGREGATION_INTERVAL):
         logging.info("Returning cached aggregated data...")
         return jsonify(cached_data)
     
     logging.info("Calculating new aggregated data...")
-    cached_data = aggregate_data()
+    aggregates_with_reference_date = list(map(
+        lambda aggregate_record: {
+            **aggregate_record,
+            "ReferenceDate": reference_date.strftime('%Y-%m-%d')
+        },
+        aggregate_data()
+    ))
+
+    cached_data = aggregates_with_reference_date
     last_aggregation_time = current_time
+
     return jsonify(cached_data)
 
 @app.route("/health", methods=["GET"])

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -352,7 +352,7 @@ services:
       PT: on
       FHIR_URL: http://on-fhir:8080/fhir # in this case, resolved inside the container, with container networking
   on-aggregator: &aggregator-service
-    image: aggregator:1.3
+    image: aggregator:1.4
     tty: ${DOCKER_TTY:-true}
     restart: always
     build:


### PR DESCRIPTION
Turned out the "bug" I was seeing was caused by a stale cached image for the aggregator service, local to my machine. I've bumped the tag to bust that cache, and added explicit documentation of the local docker image caching problem.

Also reverted the aggregator `ReferenceDate` behaviour, without bringing back deep argument drilling, to ensure that a single reference date is returned per-request.   