### PR TITLE
Clear out old PT env vars from the patient browser deployments and scripts

### DIFF
--- a/k8s/bc/patient-browser/deployment.yaml
+++ b/k8s/bc/patient-browser/deployment.yaml
@@ -21,7 +21,5 @@ spec:
         ports:
         - containerPort: 8080
         env:
-        - name: PT # TODO: delete in favour of FHIR_URL once new patient-browser docker images are pushed 
-          value: "bc"
         - name: FHIR_URL
           value: "https://fhir.bc.iidi.alpha.phac.gc.ca/fhir"

--- a/k8s/on/patient-browser/deployment.yaml
+++ b/k8s/on/patient-browser/deployment.yaml
@@ -21,7 +21,5 @@ spec:
         ports:
         - containerPort: 8080
         env:
-        - name: PT # TODO: delete in favour of FHIR_URL once new patient-browser docker images are pushed 
-          value: "on"
         - name: FHIR_URL
           value: "https://fhir.on.iidi.alpha.phac.gc.ca/fhir"

--- a/patient-browser/browser.sh
+++ b/patient-browser/browser.sh
@@ -3,13 +3,6 @@
 # Log the configuration update process
 echo "Starting Nginx configuration update script..."
 
-# TODO: this provices support for previous script behaviour where the old PT env var is set and
-# the new FHIR_URL env var isn't. Delete this case statement once the K8s deployments have been
-# updated to only use FHIR_URL
-if [[ -z "$FHIR_URL" && ! -z "$PT" ]]; then
-  FHIR_URL="https://fhir.${PT}.iidi.alpha.phac.gc.ca/fhir"
-fi
-
 # Update the FHIR server URL dynamically if FHIR_URL is set
 default_url=http://localhost:8080/fhir
 if [[ ! -z "$FHIR_URL" ]]; then


### PR DESCRIPTION
Follow up to #37, now that flux is fully syncing everything for us.