### PR TITLE
Transfer Dashboard DevEnv and DevOps

### DIFF
--- a/demo-portal/app.py
+++ b/demo-portal/app.py
@@ -19,6 +19,9 @@ entities = {
         {"name": "Patient Browser", "url": os.getenv("ON_BROWSER_URL")},
         {"name": "HAPI FHIR Server", "url": os.getenv("ON_FHIR_URL")},
         {"name": "Aggregator", "url": os.getenv("ON_AGGREGATOR_URL")}
+    ],
+    "Demo Utilities": [
+        {"name": "Patient Transfer Dashboard", "url": os.getenv("DEMO_TRANSFER_DASHBOARD_URL")},
     ]
 }
 

--- a/demo-portal/static/css/style.css
+++ b/demo-portal/static/css/style.css
@@ -157,6 +157,9 @@ html {
 .container .btn-Federator {
   background-color: #ff8c00;
 }
+.container .btn-Patient-Transfer-Dashboard {
+  background-color: #b2456e;
+}
 
 .accordion .card {
   background: #ffffff;

--- a/demo-portal/static/svg/Patient Transfer Dashboard.svg
+++ b/demo-portal/static/svg/Patient Transfer Dashboard.svg
@@ -1,0 +1,6 @@
+<svg width="18" height="19" viewBox="0 0 18 19" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M6.75 2.75H3C2.58579 2.75 2.25 3.08579 2.25 3.5V8.75C2.25 9.16421 2.58579 9.5 3 9.5H6.75C7.16421 9.5 7.5 9.16421 7.5 8.75V3.5C7.5 3.08579 7.16421 2.75 6.75 2.75Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 2.75H11.25C10.8358 2.75 10.5 3.08579 10.5 3.5V5.75C10.5 6.16421 10.8358 6.5 11.25 6.5H15C15.4142 6.5 15.75 6.16421 15.75 5.75V3.5C15.75 3.08579 15.4142 2.75 15 2.75Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M15 9.5H11.25C10.8358 9.5 10.5 9.83579 10.5 10.25V15.5C10.5 15.9142 10.8358 16.25 11.25 16.25H15C15.4142 16.25 15.75 15.9142 15.75 15.5V10.25C15.75 9.83579 15.4142 9.5 15 9.5Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+<path d="M6.75 12.5H3C2.58579 12.5 2.25 12.8358 2.25 13.25V15.5C2.25 15.9142 2.58579 16.25 3 16.25H6.75C7.16421 16.25 7.5 15.9142 7.5 15.5V13.25C7.5 12.8358 7.16421 12.5 6.75 12.5Z" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/demo-transfer-dashboard/.dockerignore
+++ b/demo-transfer-dashboard/.dockerignore
@@ -1,0 +1,5 @@
+.env*
+node_modules
+dist
+Dockerfile.*
+coverage

--- a/demo-transfer-dashboard/.nginx/nginx.conf
+++ b/demo-transfer-dashboard/.nginx/nginx.conf
@@ -1,0 +1,16 @@
+server {
+
+  listen 3000;
+
+  location / {
+    root   /usr/share/nginx/html;
+    index  index.html;
+    try_files $uri /index.html =404;
+  }
+
+  error_page   500 502 503 504  /50x.html;
+
+  location = /50x.html {
+    root   /usr/share/nginx/html;
+  }
+}

--- a/demo-transfer-dashboard/.nginx/nginx.conf
+++ b/demo-transfer-dashboard/.nginx/nginx.conf
@@ -13,4 +13,8 @@ server {
   location = /50x.html {
     root   /usr/share/nginx/html;
   }
+
+  location /healthcheck {
+    return 200 'no content';
+  }
 }

--- a/demo-transfer-dashboard/Dockerfile
+++ b/demo-transfer-dashboard/Dockerfile
@@ -1,0 +1,33 @@
+# 1. Building static react app
+FROM node:22-alpine3.21 AS build
+
+WORKDIR /app
+
+COPY package.json /app/package.json
+COPY package-lock.json /app/package-lock.json
+RUN npm ci
+
+COPY . /app
+RUN npm run build
+
+# 2. Serve static app via nginx
+FROM docker.io/library/nginx:1.27.3
+
+RUN chown -R 1000:1000 /var/cache/nginx /var/run/ 
+
+# Copy config nginx
+COPY --from=build /app/.nginx/nginx.conf /etc/nginx/conf.d/default.conf
+
+WORKDIR /usr/share/nginx/html
+
+# Remove default nginx static assets
+RUN rm -rf ./*
+
+# Copy static assets from builder stage
+COPY --from=build /app/dist .
+
+USER 1000
+EXPOSE 3000
+
+# Containers run nginx with global directives and daemon off
+ENTRYPOINT ["nginx", "-g", "daemon off;"]

--- a/demo-transfer-dashboard/cloudbuild.yaml
+++ b/demo-transfer-dashboard/cloudbuild.yaml
@@ -1,0 +1,63 @@
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    id: generate-image-name
+    entrypoint: 'bash'
+    dir: demo-transfer-dashboard
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        service="iidi-demo-transfer-dashboard"
+
+        # NOTE: $BRANCH_NAME etc aren't shell variables, they're a Cloudbuild substitution syntax.
+        # Also important to note that they depend on the trigger source, and won't be set by default
+        # if the build is triggered via the cli (`gcloud builds submit`) UNLESS the `--substitutions`
+        # flag is used to set them manually
+        image_name="northamerica-northeast1-docker.pkg.dev/$PROJECT_ID/paradire/${service}:$BRANCH_NAME-$COMMIT_SHA-$(date +%s)"
+        echo "Image name for this build (if pushed): ${image_name}"
+        echo "${image_name}" > /workspace/imagename
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: build-if-main
+    entrypoint: 'bash'
+    dir: demo-transfer-dashboard
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Building Docker image: ${image}"
+          docker build -t "${image}" -f ./Dockerfile .
+        else
+          echo "Skipping build: Not on 'main' branch"
+          exit 0
+        fi
+
+  - name: 'gcr.io/cloud-builders/docker'
+    id: push-if-main
+    entrypoint: 'bash'
+    args:
+      - '-c'
+      - |
+        set -o errexit
+        set -o pipefail
+        set -o nounset
+
+        if [[ "$BRANCH_NAME" == "main" ]]; then
+          image=$(cat /workspace/imagename)
+          echo "Pushing Docker image: ${image}"
+          docker push "${image}"
+        else
+          echo "Skipping push: Not on 'main' branch"
+          exit 0
+        fi
+
+options:
+  defaultLogsBucketBehavior: REGIONAL_USER_OWNED_BUCKET

--- a/demo-transfer-dashboard/package.json
+++ b/demo-transfer-dashboard/package.json
@@ -6,6 +6,8 @@
   "scripts": {
     "build": "rsbuild build",
     "dev": "rsbuild dev --open",
+    "dev:docker": "rsbuild dev --port ${PORT} --base ${BASE_PATH}",
+    "dev:docker-debug": "node --inspect='0.0.0.0:9229' ./node_modules/@rsbuild/core/bin/rsbuild.js dev --port ${PORT} --base ${BASE_PATH}",
     "preview": "rsbuild preview"
   },
   "dependencies": {

--- a/demo-transfer-dashboard/rsbuild.config.mjs
+++ b/demo-transfer-dashboard/rsbuild.config.mjs
@@ -3,4 +3,14 @@ import { pluginReact } from '@rsbuild/plugin-react';
 
 export default defineConfig({
   plugins: [pluginReact()],
+  source: {
+    define: {
+      'process.env.ON_OUTBOUND_URL': JSON.stringify(
+        process.env.ON_OUTBOUND_URL,
+      ),
+      'process.env.BC_OUTBOUND_URL': JSON.stringify(
+        process.env.BC_OUTBOUND_URL,
+      ),
+    },
+  },
 });

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -628,5 +628,5 @@ services:
       PORT: 3005
       BASE_PATH: /demo-transfer-dashboard # see docker-compose nginx config, the rsbuild is behind a proxy path, needs to be configured to serve relative to it
       # the demo transfer dashboard will make transfer-outbound API request from the browser, so request must go through the nginx gateway paths
-      ON_TRANSFER_URL: http://localhost:8080/on/outbound
-      BC_TRANSFER_URL: http://localhost:8080/bc/outbound
+      ON_OUTBOUND_URL: http://localhost:8080/on/outbound
+      BC_OUTBOUND_URL: http://localhost:8080/bc/outbound

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -585,7 +585,7 @@ services:
       AGGREGATOR_URL: http://federator:3000/aggregated-data
 
   demo-portal:
-    image: demo-portal:1.2
+    image: demo-portal:1.3
     tty: ${DOCKER_TTY:-true}
     build:
       context: ./demo-portal
@@ -602,6 +602,7 @@ services:
       ON_BROWSER_URL: http://localhost:8080/on/browser
       ON_FHIR_URL: http://localhost:8080/on/fhir
       ON_AGGREGATOR_URL: http://localhost:8080/on/aggregator/aggregated-data
+      DEMO_TRANSFER_DASHBOARD_URL: http://localhost:8080/demo-transfer-dashboard
   demo-transfer-dashboard:
     image: node-dev:1.0
     tty: ${DOCKER_TTY:-true}

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -283,6 +283,32 @@ configs:
 
               proxy_pass http://demo-portal:8080/;
           }
+          location /demo-transfer-dashboard/ {
+              # set proxy headers
+              proxy_set_header Host $$host;
+              proxy_set_header X-Real-IP $$remote_addr;
+              proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $$scheme;
+              
+              # WebSocket support
+              proxy_http_version 1.1;
+              proxy_set_header Upgrade $$http_upgrade;
+              proxy_set_header Connection "upgrade";
+
+              # prevent nginx from dropping the port from localhost urls
+              absolute_redirect off;
+
+              proxy_pass http://demo-transfer-dashboard:3005/demo-transfer-dashboard/;
+
+              # This part's important. rspack dev server URIs are a mix of static content resources on the server and SPA routes.
+              # If the dev server doesn't have a resource, then it must be assumed that URI is actually an SPA route,
+              # so replace UI server 404's with the index.html, to load the SPA and let it handle the route client side.
+              # In deployments, the static file server should itself use nginx with an equivalent config (using `try_file`,
+              # but that's not an option when proxying). Direct requests to the rspack dev server also work as expected by default,
+              # but not when proxied through nginx like this (nginx layers in its own 404 response by default)
+              proxy_intercept_errors on;
+              error_page 404 = /index.html;
+          }
       }
   hapi:
     file: ./hapi-dev.application.yaml
@@ -576,3 +602,31 @@ services:
       ON_BROWSER_URL: http://localhost:8080/on/browser
       ON_FHIR_URL: http://localhost:8080/on/fhir
       ON_AGGREGATOR_URL: http://localhost:8080/on/aggregator/aggregated-data
+  demo-transfer-dashboard:
+    image: node-dev:1.0
+    tty: ${DOCKER_TTY:-true}
+    restart: always
+    build:
+      context: ./node-dev-docker-env
+      dockerfile: ./Dockerfile.node-dev
+    volumes:
+      - ./demo-transfer-dashboard:/home/node-dev/project
+      - ./demo-transfer-dashboard/.env.node-dev-docker-env-overrides:/home/node-dev/project/.env
+    command: npm run dev:${DOCKER_API_COMMAND:-docker} # 'docker' or 'docker-debug'
+    networks:
+      - gateway
+        # node-dev images need to reach the internet for installing packages at run time, and to surface debug servers directly.
+        # For docker networking and prod-parity purposes, service-to-service communications should still go through the nginx gateway
+      - host-loopback
+    ports:
+      # configuring the websocket rsbuild uses to send hot reload signals is a bother with out proxy setup. The websockets can still
+      # connect, bypassing the nginx proxy, if this container is 1) conntected to the host-loopback and 2) has the same exposed container port
+      # (3005 right now) as it serves on internally (see the PORT env var below)
+      - 3005:3005
+      - 9233:9229 # for the node debug server, when active; see node-dev-docker-env/package.json `dev:docker-debug` script
+    environment:
+      PORT: 3005
+      BASE_PATH: /demo-transfer-dashboard # see docker-compose nginx config, the rsbuild is behind a proxy path, needs to be configured to serve relative to it
+      # the demo transfer dashboard will make transfer-outbound API request from the browser, so request must go through the nginx gateway paths
+      ON_TRANSFER_URL: http://localhost:8080/on/outbound
+      BC_TRANSFER_URL: http://localhost:8080/bc/outbound

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -238,8 +238,8 @@ export default [
   },
 
   {
-    // node scripts (common js) environment
-    files: ['**/*.cjs'],
+    // node scripts environment
+    files: ['**/*.cjs', '**/*.mjs'],
 
     ...nodePlugin.configs['flat/recommended-script'],
 

--- a/k8s/demo-portal/deployment.yaml
+++ b/k8s/demo-portal/deployment.yaml
@@ -40,6 +40,10 @@ spec:
               value: https://fhir.on.iidi.alpha.phac.gc.ca
             - name: ON_AGGREGATOR_URL
               value: https://aggregator.on.iidi.alpha.phac.gc.ca/aggregated-data
+            - name: DEMO_TRANSFER_DASHBOARD_URL
+              # TODO pending deployment manifests for the transfer dashboard, using the shiny dashboard as a placeholder
+              # as the code expects all URLs to be valid
+              value: 'https://rshiny-dashboard.federal.iidi.alpha.phac.gc.ca'
           resources:
             requests:
               memory: "256Mi"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "scripts": {
     "ci:all": "npm ci; (cd ./federator && npm ci); (cd ./transfer-inbound && npm ci); (cd ./transfer-outbound && npm ci); (cd ./demo-transfer-dashboard && npm ci);",
     "dev": "docker compose -f ./docker-compose.dev.yaml up",
-    "predev": "npm run dev:down; (cp --update=none ./node-dev-docker-env/reference.env.node-dev-docker-env-overrides ./federator/.env.node-dev-docker-env-overrides); (cp --update=none ./node-dev-docker-env/reference.env.node-dev-docker-env-overrides ./transfer-inbound/.env.node-dev-docker-env-overrides); (cp --update=none ./node-dev-docker-env/reference.env.node-dev-docker-env-overrides ./transfer-outbound/.env.node-dev-docker-env-overrides);",
+    "predev": "npm run dev:down; (cp --update=none ./node-dev-docker-env/reference.env.node-dev-docker-env-overrides ./federator/.env.node-dev-docker-env-overrides); (cp --update=none ./node-dev-docker-env/reference.env.node-dev-docker-env-overrides ./transfer-inbound/.env.node-dev-docker-env-overrides); (cp --update=none ./node-dev-docker-env/reference.env.node-dev-docker-env-overrides ./transfer-outbound/.env.node-dev-docker-env-overrides); (cp --update=none ./node-dev-docker-env/reference.env.node-dev-docker-env-overrides ./demo-transfer-dashboard/.env.node-dev-docker-env-overrides);",
     "dev:debug": "DOCKER_API_COMMAND=docker-debug docker compose -f ./docker-compose.dev.yaml up",
     "predev:debug": "npm run predev",
     "dev:down": "docker compose -f ./docker-compose.dev.yaml down -v",


### PR DESCRIPTION
TODO:
  - [x] added the demo transfer dashboard to the docker compose dev env
  - [x] inject BC and ON dev env `transfer-outbound` service urls in to the transfer dashboard via rsbuild
  - [x] add nginx based static content server for deploying the transfer dashboard
  - [x] add cloudbuild.yaml for the transfer dashboard
  - [x] click ops the cloudbuild trigger
    - could have let this wait for the k8s manifests, but trivial so I did it now

Follow up:
  - create k8s manifests and update the `DEMO_TRANSFER_DASHBOARD_URL` env var in the `demo-portal` deployment
    - I could do this, but no rush and I need to go back to other tasks
    - tracked in #162