### PR TITLE
Basic implemntation of get_patient_bundle_for_transfer

### DIFF
--- a/federator/src/create_app.ts
+++ b/federator/src/create_app.ts
@@ -28,8 +28,8 @@ export const create_app = async () => {
 
         const response = await fetch(aggregator_endpoint);
 
-        if (response.status === 200) {
-          const aggregated_data = await response.json();
+        if (response.ok) {
+          const aggregated_data = await response.json().catch(() => null);
 
           if (is_valid_aggregated_data(aggregated_data)) {
             return aggregated_data;

--- a/node-dev-docker-env/wait_for_service.cjs
+++ b/node-dev-docker-env/wait_for_service.cjs
@@ -13,8 +13,8 @@ if (endpoint === undefined) {
 
 const try_fetch = (retry_count) =>
   fetch(endpoint)
-    .then(({ status }) => {
-      if (status === 200) {
+    .then((response) => {
+      if (response.ok) {
         console.log(`Service at ${endpoint} responded successfully!`);
         return process.exit(0);
       } else if (retry_count >= retry_max) {

--- a/transfer-outbound/src/fhir_utils.ts
+++ b/transfer-outbound/src/fhir_utils.ts
@@ -2,6 +2,10 @@ import type { Patient, Bundle } from 'fhir/r4.d.ts';
 
 import { get_env } from './env.ts';
 import { AppError } from './error_utils.ts';
+import {
+  assert_patient_id_parameter_is_valid,
+  assert_transfer_code_parameter_is_valid,
+} from './request_parameter_validation_utils.ts';
 import type { transferCode } from './transfer_code_utils.ts';
 
 const is_patient_resource = (json: unknown): json is Patient =>
@@ -38,6 +42,8 @@ const handle_fhir_response_error = async (response: Response) => {
 export const assert_patient_exists_and_is_untransfered = async (
   patient_id: string,
 ) => {
+  assert_patient_id_parameter_is_valid(patient_id);
+
   const { FHIR_URL } = get_env();
 
   const response = await fetch(`${FHIR_URL}/Patient/${patient_id}`);
@@ -71,6 +77,8 @@ export const assert_patient_exists_and_is_untransfered = async (
 };
 
 export const get_patient_bundle_for_transfer = async (patient_id: string) => {
+  assert_patient_id_parameter_is_valid(patient_id);
+
   const { FHIR_URL } = get_env();
 
   const response = await fetch(
@@ -96,10 +104,13 @@ export const get_patient_bundle_for_transfer = async (patient_id: string) => {
 };
 
 export const mark_patient_transfering = async (
-  _patient_id: string,
-  _transfer_to: transferCode,
+  patient_id: string,
+  transfer_to: transferCode,
   _transfer_request_id?: string,
 ) => {
+  assert_patient_id_parameter_is_valid(patient_id);
+  assert_transfer_code_parameter_is_valid(transfer_to);
+
   const { FHIR_URL } = get_env();
 
   // TODO mark patient as being transfered out in outbound province FHIR server,
@@ -116,10 +127,13 @@ export const mark_patient_transfering = async (
 };
 
 export const unmark_patient_transfering = async (
-  _patient_id: string,
-  _transfer_to: transferCode,
+  patient_id: string,
+  transfer_to: transferCode,
   _transfer_request_id?: string,
 ) => {
+  assert_patient_id_parameter_is_valid(patient_id);
+  assert_transfer_code_parameter_is_valid(transfer_to);
+
   const { FHIR_URL } = get_env();
 
   // TODO need to be able to revert the transfer mark if the bundle is rejected by the inbound service
@@ -133,9 +147,14 @@ export const unmark_patient_transfering = async (
 };
 
 export const mark_patient_transfered = async (
-  _patient_id: string,
-  _new_patient_id?: string,
+  patient_id: string,
+  new_patient_id?: string,
 ) => {
+  assert_patient_id_parameter_is_valid(patient_id);
+  if (new_patient_id !== undefined) {
+    assert_patient_id_parameter_is_valid(new_patient_id);
+  }
+
   const { FHIR_URL } = get_env();
 
   // TODO mark patient as fully transfered out in province FHIR server, add id of patient in inbound system
@@ -146,5 +165,6 @@ export const mark_patient_transfered = async (
     'Patient transfer marking method not implemented yet',
   );
 
+  assert_patient_id_parameter_is_valid(patient_id);
   await fetch(`${FHIR_URL}/TODO`);
 };

--- a/transfer-outbound/src/fhir_utils.ts
+++ b/transfer-outbound/src/fhir_utils.ts
@@ -83,9 +83,6 @@ export const get_patient_bundle_for_transfer = async (patient_id: string) => {
     const json = await response.json().catch(() => null);
 
     if (is_bundle_resource(json)) {
-      // TODO should the entire bundle be returned as-is with all metadata? Only the data?
-      // Should some fields be stripped/sanitized at this point? "link" values?
-      // Should any filtering rules come from from configuration (issue #110)?
       return json;
     } else {
       throw new AppError(

--- a/transfer-outbound/src/transfer_request_queue/transferRequest.d.ts
+++ b/transfer-outbound/src/transfer_request_queue/transferRequest.d.ts
@@ -1,5 +1,4 @@
 import type { transferCode } from 'src/transfer_code_utils.ts';
-import type { bundle } from 'src/types.d.ts';
 
 import type { transferStage } from './transfer_stage_utils.ts';
 
@@ -8,6 +7,5 @@ export interface transferRequest {
   transfer_to: transferCode;
   stage: transferStage;
   completed_stages: transferStage[];
-  bundle?: bundle;
   new_patient_id?: string;
 }

--- a/transfer-outbound/src/transfer_request_queue/transfer_stage_utils.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_stage_utils.ts
@@ -1,12 +1,11 @@
-export const initial_stage = 'collecting';
+export const initial_stage = 'marking_as_transfering';
 
 export const terminal_stage = 'done';
 
 export const transfer_stages = [
   initial_stage,
-  'marking_transfered',
-  'transfering',
-  'finalizing',
+  'collecting_and_transfering',
+  'marking_transferred',
   terminal_stage,
 ] as const;
 export type transferStage = (typeof transfer_stages)[number];
@@ -17,10 +16,9 @@ const non_terminal_transfer_stages = transfer_stages.filter(
 type nonTerminalTransferStage = (typeof non_terminal_transfer_stages)[number];
 
 const next_stage_map: Record<nonTerminalTransferStage, transferStage> = {
-  collecting: 'marking_transfered',
-  marking_transfered: 'transfering',
-  transfering: 'finalizing',
-  finalizing: terminal_stage,
+  marking_as_transfering: 'collecting_and_transfering',
+  collecting_and_transfering: 'marking_transferred',
+  marking_transferred: terminal_stage,
 };
 export const get_next_stage = (
   current_stage: Exclude<transferStage, typeof terminal_stage>,

--- a/transfer-outbound/src/transfer_request_queue/transfer_worker.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_worker.ts
@@ -57,18 +57,18 @@ const work_on_transfer_job = async (job: transferRequestJob) => {
         job.data.transfer_to,
       );
 
-      if (transfer_response.status === 200) {
-        const body = await transfer_response.json();
+      if (transfer_response.ok) {
+        const json = await transfer_response.json().catch(() => null);
 
         if (
-          typeof body === 'object' &&
-          body !== null &&
-          'new_patient_id' in body &&
-          typeof body.new_patient_id === 'string'
+          typeof json === 'object' &&
+          json !== null &&
+          'new_patient_id' in json &&
+          typeof json.new_patient_id === 'string'
         ) {
           await job.updateData({
             ...job.data,
-            new_patient_id: body.new_patient_id,
+            new_patient_id: json.new_patient_id,
           });
         }
       } else {

--- a/transfer-outbound/src/transfer_request_queue/transfer_worker.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_worker.ts
@@ -37,23 +37,17 @@ const work_on_transfer_job = async (job: transferRequestJob) => {
     // TODO for this and all other logging found here, switch to a good struct log approach. These simple logs are placeholders/for dev
     console.log(`Job ID ${job.id}: starting stage "${job.data.stage}"`);
 
-    if (job.data.stage === 'collecting') {
-      const bundle = await get_patient_bundle_for_transfer(job.data.patient_id);
-      await job.updateData({
-        ...job.data,
-        bundle,
-      });
-    } else if (job.data.stage === 'marking_transfered') {
+    if (job.data.stage === 'marking_as_transfering') {
       await mark_patient_transfering(
         job.data.patient_id,
         job.data.transfer_to,
         job.id,
       );
-    } else if (job.data.stage === 'transfering') {
-      // NOTE: vital assumption: this end point returns 200 IF AND ONLY IF the bundle was accepted and fully written to the receiving
-      // FHIR server. Not a big ask, just have to hold to that or else the rollback handling won't work and data integrity is lost
+    } else if (job.data.stage === 'collecting_and_transfering') {
+      const bundle = await get_patient_bundle_for_transfer(job.data.patient_id);
+
       const transfer_response = await post_bundle_to_inbound_transfer_service(
-        job.data.bundle,
+        bundle,
         job.data.transfer_to,
       );
 
@@ -76,7 +70,9 @@ const work_on_transfer_job = async (job: transferRequestJob) => {
           `Job ID ${job.id}: inbound-transfer service for "${job.data.transfer_to}" responded to patient ID "${job.data.patient_id}" transfer with a "${transfer_response.status}" status`,
         );
       }
-    } else if (job.data.stage === 'finalizing') {
+    } else if (job.data.stage === 'marking_transferred') {
+      // NOTE: vital assumption: this end point returns 200 IF AND ONLY IF the bundle was accepted and fully written to the receiving
+      // FHIR server. Not a big ask, just have to hold to that or else the rollback handling won't work and data integrity is lost
       await mark_patient_transfered(
         job.data.patient_id,
         job.data.new_patient_id,
@@ -106,32 +102,29 @@ const handle_failed_transfer_request_job = async (
     `Job ID ${failed_job.id}: failed on stage "${failed_job.data.stage}" having completed stages [${failed_job.data.completed_stages.join(', ')}]`,
   );
 
-  const transfer_marks_were_created =
-    failed_job.data.completed_stages.includes('marking_transfered');
+  const transfering_marks_were_created =
+    failed_job.data.completed_stages.includes('marking_as_transfering');
 
-  const transfer_completed =
-    failed_job.data.completed_stages.includes('transfering');
+  const transfer_completed = failed_job.data.completed_stages.includes(
+    'collecting_and_transfering',
+  );
 
-  const transfer_finalized =
-    failed_job.data.completed_stages.includes('finalizing');
+  const transferred_marks_were_created =
+    failed_job.data.completed_stages.includes('marking_transferred');
 
-  if (
-    (transfer_finalized &&
-      !(transfer_marks_were_created || transfer_completed)) ||
-    (transfer_completed && !transfer_marks_were_created)
-  ) {
+  if (!transfering_marks_were_created && transfer_completed) {
     console.error(
       `Job ID ${failed_job.id} failure handing: reached an unexpected state! This should really not happen, and means we can't guarantee data integrity!"`,
     );
   }
 
-  if (!transfer_marks_were_created) {
+  if (!transfering_marks_were_created) {
     console.log(
       `Job ID ${failed_job.id} failure handling: nothing to clean up"`,
     );
-  } else if (transfer_marks_were_created && !transfer_completed) {
+  } else if (transfering_marks_were_created && !transfer_completed) {
     console.log(
-      `Job ID ${failed_job.id} failure handling: attempting to roll back outbound patient transfer marking"`,
+      `Job ID ${failed_job.id} failure handling: attempting to roll back outbound patient transfering markers"`,
     );
 
     await unmark_patient_transfering(
@@ -141,12 +134,12 @@ const handle_failed_transfer_request_job = async (
     );
 
     console.log(
-      `Job ID ${failed_job.id} failure handling: successfully rolled back outbound patient transfer marking"`,
+      `Job ID ${failed_job.id} failure handling: successfully rolled back outbound patient transfering markers"`,
     );
   } else if (
-    transfer_marks_were_created &&
+    transfering_marks_were_created &&
     transfer_completed &&
-    !transfer_finalized
+    !transferred_marks_were_created
   ) {
     if (failed_job.attemptsMade <= (failed_job.opts.attempts ?? 3) + 3) {
       const next_delay =


### PR DESCRIPTION
TODO:
  - [x] simplest/most naive implementation
  - ~might be worth stripping some of the bundle metadata before storing it in the queue/sending it to the inbound endpoint~
    - no longer storing bundles on the queue, so that portions no longer a concern
    - whether metadata/certain fields should be stripped before transferring to the inbound endpoint is a more involved question, ultimately going to depend on provincial policies/legislation/data sharing agreements to some extent. Out of scope
  - [x] should double check that queue logging never includes bundle content (and enforce that going forward)
    - achieved by no longer storing the bundle information on the queue

Follow up:
  - accepting configuration env vars for bundle content/filtering rules will be left off for later. See #110
  
Closes #112