### PR TITLE
Patient transfer metadata handling

### DIFF
--- a/transfer-outbound/src/create_app.ts
+++ b/transfer-outbound/src/create_app.ts
@@ -5,7 +5,7 @@ import { get_env } from './env.ts';
 
 import { expressErrorHandler } from './error_utils.ts';
 import {
-  assert_patient_exists_and_is_untransfered,
+  assert_patient_exists_and_can_be_transfered,
   get_patient_bundle_for_transfer,
 } from './fhir_utils.ts';
 import {
@@ -60,7 +60,7 @@ export const create_app = async () => {
     assert_patient_id_parameter_is_valid(patient_id);
     assert_transfer_code_parameter_is_valid(transfer_to);
 
-    await assert_patient_exists_and_is_untransfered(patient_id);
+    await assert_patient_exists_and_can_be_transfered(patient_id);
 
     const transfer_request_job = await initialize_transfer_request(
       patient_id,
@@ -76,7 +76,7 @@ export const create_app = async () => {
     const { patient_id } = req.body;
     assert_patient_id_parameter_is_valid(patient_id);
 
-    await assert_patient_exists_and_is_untransfered(patient_id);
+    await assert_patient_exists_and_can_be_transfered(patient_id);
 
     const bundle = await get_patient_bundle_for_transfer(patient_id);
 

--- a/transfer-outbound/src/fhir_utils.ts
+++ b/transfer-outbound/src/fhir_utils.ts
@@ -20,7 +20,7 @@ const is_bundle_resource = (json: unknown): json is Bundle =>
   'resourceType' in json &&
   json?.resourceType === 'Bundle';
 
-const handle_fhir_response_error = async (response: Response) => {
+const get_error_from_fhir_response = async (response: Response) => {
   const json = (await response.json().catch(() => null)) as {
     issue?: [{ diagnostics?: string }];
   } | null;
@@ -30,18 +30,16 @@ const handle_fhir_response_error = async (response: Response) => {
     .join(', ');
 
   if (fhir_diagnostic_messages !== undefined) {
-    throw new AppError(response.status, fhir_diagnostic_messages);
+    return new AppError(response.status, fhir_diagnostic_messages);
   } else {
-    throw new AppError(
+    return new AppError(
       response.status,
       `FHIR request returned code "${response.status}", no diagnostic messages available`,
     );
   }
 };
 
-export const assert_patient_exists_and_is_untransfered = async (
-  patient_id: string,
-) => {
+const get_patient = async (patient_id: string) => {
   assert_patient_id_parameter_is_valid(patient_id);
 
   const { FHIR_URL } = get_env();
@@ -52,30 +50,35 @@ export const assert_patient_exists_and_is_untransfered = async (
     const json = await response.json().catch(() => null);
 
     if (is_patient_resource(json)) {
-      // TODO transfer mark storage specific TBD, see set_patient_transfer_metadata_and_lock method
-      const patient_transfered_to = json.extension?.find(
-        ({ url }) =>
-          url ===
-          'TODO if we want to store transfer status as an extension, we need to publish the spec def at a known url',
-      )?.valueString;
-
-      if (patient_transfered_to !== undefined) {
-        throw new AppError(
-          400,
-          `Patient "${patient_id}" exists, but has already been transfered out to "${patient_transfered_to}"`,
-        );
-      }
+      return json;
     } else {
       throw new AppError(
         500,
-        `FHIR server returned a non-Patient resource for id "${patient_id}". This should never happen`,
+        `Invalid response from FHIR server for patient ID "${patient_id}": response status was "ok", but response body was not a valid Patient resource`,
       );
     }
   } else {
-    await handle_fhir_response_error(response);
+    throw await get_error_from_fhir_response(response);
   }
 };
 
+export const assert_patient_exists_and_can_be_transfered = async (
+  patient_id: string,
+) => {
+  const patient = await get_patient(patient_id);
+
+  const replaced_by = patient.link?.find(({ type }) => type === 'replaced-by');
+  if (replaced_by !== undefined) {
+    // See https://www.hl7.org/fhir/references.html#reference
+    throw new AppError(
+      400,
+      `Patient "${patient_id}" exists, but is non-authoratative, having been replaced by a newer patient record. See reference:\n` +
+        JSON.stringify(replaced_by, null, 2),
+    );
+  }
+};
+
+// TODO: might be worth having a short-lived in-memory cache here, to spare the FHIR thrashing if retries occur during the work loop
 export const get_patient_bundle_for_transfer = async (patient_id: string) => {
   assert_patient_id_parameter_is_valid(patient_id);
 
@@ -99,56 +102,73 @@ export const get_patient_bundle_for_transfer = async (patient_id: string) => {
       );
     }
   } else {
-    await handle_fhir_response_error(response);
+    throw await get_error_from_fhir_response(response);
   }
 };
 
-export const set_patient_transfer_metadata_and_lock = async (
+export const set_replaced_by_link_on_transfered_patient = async (
   patient_id: string,
-  _transfer_request_id: string,
-  transfer_to: transferCode,
-  // TODO other transfer metadata might be relevant to store, but likely not in scope right now
-) => {
-  assert_patient_id_parameter_is_valid(patient_id);
-  assert_transfer_code_parameter_is_valid(transfer_to);
-
-  // TODO mark patient as being transfered out in outbound province FHIR server,
-  // possibly with a FHIR spec extension field for the inbound province and transfer request ID,
-  // expect this to happen after bundle collection step and before the bundle
-  // is sent to the inbound service
-
-  // const { FHIR_URL } = get_env();
-
-  // await fetch(`${FHIR_URL}/TODO`);
-};
-
-export const unset_patient_transfer_metadata_and_lock = async (
-  patient_id: string,
-  _transfer_request_id: string,
-) => {
-  assert_patient_id_parameter_is_valid(patient_id);
-
-  // TODO need to be able to revert the transfer mark if the bundle is rejected by the inbound service
-
-  // const { FHIR_URL } = get_env();
-
-  // await fetch(`${FHIR_URL}/TODO`);
-};
-
-export const set_patient_post_transfer_metadata = async (
-  patient_id: string,
-  _transfer_request_id: string,
+  transfer_request_id: string,
+  transfer_code: transferCode,
   new_patient_id?: string,
 ) => {
   assert_patient_id_parameter_is_valid(patient_id);
+  assert_transfer_code_parameter_is_valid(transfer_code);
   if (new_patient_id !== undefined) {
     assert_patient_id_parameter_is_valid(new_patient_id);
   }
 
-  // TODO mark patient as fully transfered out in province FHIR server, add id of patient in inbound system
-  // Might not want to assume the inbound province shared a new patient ID, cover case where it's undefined
+  const { FHIR_URL, OWN_TRANSFER_CODE } = get_env();
 
-  // const { FHIR_URL } = get_env();
+  // IMPORTANT: the behaviour here is tightly coupled to the logic of assert_patient_exists_and_can_be_transfered
 
-  // await fetch(`${FHIR_URL}/TODO`);
+  // References:
+  //    https://www.hl7.org/fhir/patient-definitions.html#Patient.link
+  //    https://www.hl7.org/fhir/valueset-link-type.html
+  //    https://www.hl7.org/fhir/references.html#logical
+  //    https://build.fhir.org/patient.html#links
+
+  const patient = await get_patient(patient_id);
+
+  const replaced_by_link = {
+    type: 'replaced-by',
+    other: {
+      type: 'Patient',
+      display: JSON.stringify({
+        explanation: `This patient and their immunization records have been transfered from "${OWN_TRANSFER_CODE}" to "${transfer_code}".`,
+        transfer_request_id,
+        transfered_from: OWN_TRANSFER_CODE,
+        transfered_to: transfer_code,
+        patient_id_in_recipient_system: new_patient_id ?? 'unknown',
+      }),
+      identifier: {
+        system: 'TODO', // TODO considering having the inbound system return the URL of the receiving FHIR server, even if it can't be reached externally
+        value: new_patient_id,
+      },
+    },
+  };
+
+  const response = await fetch(`${FHIR_URL}/Patient/${patient_id}`, {
+    method: 'PATCH',
+    headers: {
+      'content-type': 'application/json-patch+json',
+    },
+    body: JSON.stringify([
+      patient?.link !== undefined
+        ? {
+            op: 'add',
+            path: '/link/-', // push to existing link array
+            value: replaced_by_link,
+          }
+        : {
+            op: 'add',
+            path: '/link', // make new link array
+            value: [replaced_by_link],
+          },
+    ]),
+  });
+
+  if (!response.ok) {
+    throw await get_error_from_fhir_response(response);
+  }
 };

--- a/transfer-outbound/src/fhir_utils.ts
+++ b/transfer-outbound/src/fhir_utils.ts
@@ -52,7 +52,7 @@ export const assert_patient_exists_and_is_untransfered = async (
     const json = await response.json().catch(() => null);
 
     if (is_patient_resource(json)) {
-      // TODO transfer mark storage specific TBD, see mark_patient_transfering method
+      // TODO transfer mark storage specific TBD, see set_patient_transfer_metadata_and_lock method
       const patient_transfered_to = json.extension?.find(
         ({ url }) =>
           url ===
@@ -103,10 +103,11 @@ export const get_patient_bundle_for_transfer = async (patient_id: string) => {
   }
 };
 
-export const mark_patient_transfering = async (
+export const set_patient_transfer_metadata_and_lock = async (
   patient_id: string,
+  _transfer_request_id: string,
   transfer_to: transferCode,
-  _transfer_request_id?: string,
+  // TODO other transfer metadata might be relevant to store, but likely not in scope right now
 ) => {
   assert_patient_id_parameter_is_valid(patient_id);
   assert_transfer_code_parameter_is_valid(transfer_to);
@@ -121,13 +122,11 @@ export const mark_patient_transfering = async (
   // await fetch(`${FHIR_URL}/TODO`);
 };
 
-export const unmark_patient_transfering = async (
+export const unset_patient_transfer_metadata_and_lock = async (
   patient_id: string,
-  transfer_to: transferCode,
-  _transfer_request_id?: string,
+  _transfer_request_id: string,
 ) => {
   assert_patient_id_parameter_is_valid(patient_id);
-  assert_transfer_code_parameter_is_valid(transfer_to);
 
   // TODO need to be able to revert the transfer mark if the bundle is rejected by the inbound service
 
@@ -136,8 +135,9 @@ export const unmark_patient_transfering = async (
   // await fetch(`${FHIR_URL}/TODO`);
 };
 
-export const mark_patient_transfered = async (
+export const set_patient_post_transfer_metadata = async (
   patient_id: string,
+  _transfer_request_id: string,
   new_patient_id?: string,
 ) => {
   assert_patient_id_parameter_is_valid(patient_id);

--- a/transfer-outbound/src/transfer_request_queue/transfer_request_utils.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_request_utils.ts
@@ -28,6 +28,9 @@ export const initialize_transfer_request = async (
       completed_stages: [],
     },
     {
+      // IMPORTANT: this is effectively our transfer-lock mechanism, important that a patient can't have more than one active
+      // transfer request at a time (and if the transfer succeeds, assume the patient resource is updated in such a way as
+      // to no longer be considered valid to queue a transfer job for)
       deduplication: { id: patient_id },
     },
   );

--- a/transfer-outbound/src/transfer_request_queue/transfer_stage_utils.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_stage_utils.ts
@@ -1,10 +1,9 @@
-export const initial_stage = 'setting_patient_transfer_metadata_and_lock';
+export const initial_stage = 'collecting_and_transfering';
 
 export const terminal_stage = 'done';
 
 export const transfer_stages = [
   initial_stage,
-  'collecting_and_transfering',
   'setting_patient_post_transfer_metadata',
   terminal_stage,
 ] as const;
@@ -16,7 +15,6 @@ const non_terminal_transfer_stages = transfer_stages.filter(
 type nonTerminalTransferStage = (typeof non_terminal_transfer_stages)[number];
 
 const next_stage_map: Record<nonTerminalTransferStage, transferStage> = {
-  setting_patient_transfer_metadata_and_lock: 'collecting_and_transfering',
   collecting_and_transfering: 'setting_patient_post_transfer_metadata',
   setting_patient_post_transfer_metadata: terminal_stage,
 };

--- a/transfer-outbound/src/transfer_request_queue/transfer_stage_utils.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_stage_utils.ts
@@ -1,11 +1,11 @@
-export const initial_stage = 'marking_as_transfering';
+export const initial_stage = 'setting_patient_transfer_metadata_and_lock';
 
 export const terminal_stage = 'done';
 
 export const transfer_stages = [
   initial_stage,
   'collecting_and_transfering',
-  'marking_transferred',
+  'setting_patient_post_transfer_metadata',
   terminal_stage,
 ] as const;
 export type transferStage = (typeof transfer_stages)[number];
@@ -16,9 +16,9 @@ const non_terminal_transfer_stages = transfer_stages.filter(
 type nonTerminalTransferStage = (typeof non_terminal_transfer_stages)[number];
 
 const next_stage_map: Record<nonTerminalTransferStage, transferStage> = {
-  marking_as_transfering: 'collecting_and_transfering',
-  collecting_and_transfering: 'marking_transferred',
-  marking_transferred: terminal_stage,
+  setting_patient_transfer_metadata_and_lock: 'collecting_and_transfering',
+  collecting_and_transfering: 'setting_patient_post_transfer_metadata',
+  setting_patient_post_transfer_metadata: terminal_stage,
 };
 export const get_next_stage = (
   current_stage: Exclude<transferStage, typeof terminal_stage>,

--- a/transfer-outbound/src/transfer_request_queue/transfer_worker.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_worker.ts
@@ -4,7 +4,7 @@ import { Worker, QueueEvents, Job } from 'bullmq';
 
 import {
   get_patient_bundle_for_transfer,
-  set_replaced_by_link_on_transfered_patient,
+  add_replaced_by_link_to_transfered_patient,
 } from 'src/fhir_utils.ts';
 
 import { post_bundle_to_inbound_transfer_service } from 'src/transfer_inbound_utils.ts';
@@ -85,7 +85,7 @@ const work_on_transfer_job = async (job: transferRequestJob) => {
     } else if (job.data.stage === 'setting_patient_post_transfer_metadata') {
       // NOTE: vital assumption: this end point returns 200 IF AND ONLY IF the bundle was accepted and fully written to the receiving
       // FHIR server. Not a big ask, just have to hold to that or else the rollback handling won't work and data integrity is lost
-      await set_replaced_by_link_on_transfered_patient(
+      await add_replaced_by_link_to_transfered_patient(
         job.data.patient_id,
         get_job_id(job),
         job.data.transfer_to,


### PR DESCRIPTION
- Simplified the worker loop, removed the pre-transfer patient record "marking" phase, which also removes the need for a rollback step in the failure handling queue
  - see TODO comments in code, I anticipate adding an additional work stage back in for explicitly "rejected" transfers, to differentiate validation failure cases from generic failure handling cases. That can be a followup PR though.
- The new logic is that a patient can't be transfered if its links includes a "replaced-by" entry (assumption that the patient record is no longer "authoritative", and the transfer request should be re-made targeting the newer, "replacing", record)
- Once a patient has been transfered in to a new province, a "replaced-by" link is added to the patient in the outbound system
  - per the new "...can_be_transfered" logic, this will prevent the patient being re-transfered from the original province going forward, as the province doesn't own the authoritative instance anymore
  - note that the link can be assumed to be unfollowable from the outgoing province, as it points to a patient in a different province's system. This is allowable/expected in some cases per the FHIR spec, see comments and reference links in the code. It is possible that existing code in any given province's secondary systems plugged in to their FHIR might not account for this documented case though, if they assume all "replaced-by" links will be in-system 
  - at the moment, I'm also marking the transferred record as inactive (`active: false`) in the outgoing system, but see the comment on that section of code + the linked documentation; that may be debatable if there's any reason for a valid operation on this patient in the old province, post transfer (assume no for now)

Potential post PoC follow-ups to consider/to document for lessons-learned:
  - receiving province could use a "replaces" type link to point back to the province and patient ID it is a continuation of
    - this one is borderline worth squeezing in to the PoC IMO
  - the process of bundling a patient for transfer may need to check and follow up on patient links, to collect all relevant records. Not in scope for the PoC, and involves a lot of potentially province-specific business logic/FHIR use cases. Just a note for going forward
  - alternative metadata/book keeping approaches: 
    - rather than links (which have pros and cons for this use case), FHIR extension definitions could be published to define a new standard for associating PT-to-PT transfer data with FHIR records
    - rather than storing any knowledge of transfers inside the FHIR systems themselves, the transfer services could own the long term transfer record keeping and lookup responsibilities. If not every province uses a FHIR compliant system, this may be more flexible and better bridge the gap. Depending on the design, it could provide good solutions to currently out of scope challenges (e.g. how to handle patients who move out and then back in). Comes with its own pros and cons (e.g. inefficient for lookup, one FHIR query may need to make many calls to one or more transfer services if the transfered status is relevant to the query)
  
Some other potentially in-scope follow up items exist in the code as TODO comments, won't list them all here. 

Closes #122 