### PR TITLE
Correct the transfer-outbound virtual-service routes

### DIFF
--- a/k8s/bc/virtual-service.yaml
+++ b/k8s/bc/virtual-service.yaml
@@ -49,6 +49,6 @@ spec:
               exact: "transfer-outbound.bc.iidi.alpha.phac.gc.ca"
       route:
         - destination:
-            host: transfer-outbound-svc.bc.svc.cluster.local
+            host: transfer-outbound.bc.svc.cluster.local
             port:
               number: 3000

--- a/k8s/on/virtual-service.yaml
+++ b/k8s/on/virtual-service.yaml
@@ -49,6 +49,6 @@ spec:
               exact: "transfer-outbound.on.iidi.alpha.phac.gc.ca"
       route:
         - destination:
-            host: transfer-outbound-svc.on.svc.cluster.local
+            host: transfer-outbound.on.svc.cluster.local
             port:
               number: 3000


### PR DESCRIPTION
Missed this in review. There were extraneous `-svc` suffixes in there. Alternatively, I could keep the `-svc` in the virtual service manifests and update the names in the corresponding `transfer-outbound-service.yaml` files, if we want `-svc` to be the naming convention :+1: 