### PR TITLE
transfer-outbound server CORS

### DIFF
--- a/k8s/bc/bc-transfer/transfer-outbound.yaml
+++ b/k8s/bc/bc-transfer/transfer-outbound.yaml
@@ -40,5 +40,5 @@ spec:
                 secretKeyRef:
                   name: redis-secret
                   key: REDIS_PASSWORD
-            - name: TRANSFER_DASHBOARD_ORIGIN
-              value: "demo-transfer-dashboard.iidi.alpha.phac.gc.ca"
+            - name: TRANSFER_DASHBOARD_ORIGINS
+              value: "https://demo-transfer-dashboard.iidi.alpha.phac.gc.ca,http://localhost:8080,http://localhost:3000,http://localhost:3005"

--- a/k8s/bc/bc-transfer/transfer-outbound.yaml
+++ b/k8s/bc/bc-transfer/transfer-outbound.yaml
@@ -40,3 +40,5 @@ spec:
                 secretKeyRef:
                   name: redis-secret
                   key: REDIS_PASSWORD
+            - name: TRANSFER_DASHBOARD_ORIGIN
+              value: "demo-transfer-dashboard.iidi.alpha.phac.gc.ca"

--- a/k8s/on/on-transfer/transfer-outbound.yaml
+++ b/k8s/on/on-transfer/transfer-outbound.yaml
@@ -41,4 +41,4 @@ spec:
                   name: redis-secret
                   key: REDIS_PASSWORD
             - name: TRANSFER_DASHBOARD_ORIGIN
-              value: "https://demo-transfer-dashboard.iidi.alpha.phac.gc.ca"
+              value: "https://demo-transfer-dashboard.iidi.alpha.phac.gc.ca,http://localhost:8080,http://localhost:3000,http://localhost:3005"

--- a/k8s/on/on-transfer/transfer-outbound.yaml
+++ b/k8s/on/on-transfer/transfer-outbound.yaml
@@ -40,3 +40,5 @@ spec:
                 secretKeyRef:
                   name: redis-secret
                   key: REDIS_PASSWORD
+            - name: TRANSFER_DASHBOARD_ORIGIN
+              value: "https://demo-transfer-dashboard.iidi.alpha.phac.gc.ca"

--- a/transfer-outbound/package-lock.json
+++ b/transfer-outbound/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@whatwg-node/node-fetch": "^0.7.0",
         "bullmq": "^5.40.3",
+        "cors": "^2.8.5",
         "dotenv": "^16.0.3",
         "envalid": "^8.0.0",
         "express": "^5.0.1",
@@ -22,6 +23,7 @@
       "devDependencies": {
         "@jest/globals": "^29.7.0",
         "@types/cookie-parser": "^1.4.8",
+        "@types/cors": "^2.8.17",
         "@types/express": "^5.0.0",
         "@types/fhir": "^0.0.41",
         "@types/jest": "^29.5.14",
@@ -1489,6 +1491,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.17",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.17.tgz",
+      "integrity": "sha512-8CGDvrBj1zgo2qE+oS3pOCyYNqCPryMWY2bGfwA0dcfopWGgxs+78df0Rs3rc9THP4JkOhLsAa+15VdpAqkcUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/express": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
@@ -2483,6 +2495,19 @@
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -4826,6 +4851,15 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/object-inspect": {

--- a/transfer-outbound/package.json
+++ b/transfer-outbound/package.json
@@ -22,6 +22,7 @@
   "dependencies": {
     "@whatwg-node/node-fetch": "^0.7.0",
     "bullmq": "^5.40.3",
+    "cors": "^2.8.5",
     "dotenv": "^16.0.3",
     "envalid": "^8.0.0",
     "express": "^5.0.1",
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@jest/globals": "^29.7.0",
     "@types/cookie-parser": "^1.4.8",
+    "@types/cors": "^2.8.17",
     "@types/express": "^5.0.0",
     "@types/fhir": "^0.0.41",
     "@types/jest": "^29.5.14",

--- a/transfer-outbound/src/create_app.ts
+++ b/transfer-outbound/src/create_app.ts
@@ -1,4 +1,7 @@
+import cors from 'cors';
 import express from 'express';
+
+import { get_env } from './env.ts';
 
 import { expressErrorHandler } from './error_utils.ts';
 import {
@@ -18,10 +21,16 @@ import {
 } from './transfer_request_queue/transfer_request_utils.ts';
 
 export const create_app = async () => {
+  const { TRANSFER_DASHBOARD_ORIGIN } = get_env();
+
   const app = express();
 
   // we'll need to be able to read `X-Forwarded-*` headers, both in prod and when using the dev docker setup
   app.set('trust proxy', true);
+
+  // Only need CORS for PoC demo purposes, given the React SPA demo dashboard.
+  // Wouldn't expect browsers to be directly hitting this API in reality
+  app.use(cors({ origin: TRANSFER_DASHBOARD_ORIGIN }));
 
   app.use(express.json()); // parses JSON body payloads, converts req.body from a string to object
   app.use(express.urlencoded({ extended: false })); // parses URL-encoded payload parameters on POST/PUT in to req.body fields

--- a/transfer-outbound/src/create_app.ts
+++ b/transfer-outbound/src/create_app.ts
@@ -21,7 +21,7 @@ import {
 } from './transfer_request_queue/transfer_request_utils.ts';
 
 export const create_app = async () => {
-  const { TRANSFER_DASHBOARD_ORIGIN } = get_env();
+  const { TRANSFER_DASHBOARD_ORIGINS } = get_env();
 
   const app = express();
 
@@ -30,13 +30,13 @@ export const create_app = async () => {
 
   // Only need CORS for PoC demo purposes, given the React SPA demo dashboard.
   // Wouldn't expect browsers to be directly hitting this API in reality
-  app.use(cors({ origin: TRANSFER_DASHBOARD_ORIGIN }));
+  app.use(cors({ origin: TRANSFER_DASHBOARD_ORIGINS }));
 
   app.use(express.json()); // parses JSON body payloads, converts req.body from a string to object
   app.use(express.urlencoded({ extended: false })); // parses URL-encoded payload parameters on POST/PUT in to req.body fields
 
   app.get('/healthcheck', (_req, res) => {
-    // TODO consider if a non-trivial healthcheck is appropriate/useful
+    // TODO consider if a non-trivial healthcheck is appropriate/useful.
     res.status(200).send();
   });
 

--- a/transfer-outbound/src/env.ts
+++ b/transfer-outbound/src/env.ts
@@ -32,6 +32,23 @@ const urlByTransferCode = makeValidator((val: string) => {
   }
 });
 
+const originList = makeValidator((val: string) => {
+  if (val === '*') {
+    return val;
+  } else {
+    const url_list = val.split(',');
+    if (
+      url_list.every((value) => validator.isURL(value, { require_tld: false }))
+    ) {
+      return url_list;
+    } else {
+      throw new Error(
+        `Expected JSON string mapping PT codes (${transfer_codes.join(', ')}) to transfer-inbound service URLs`,
+      );
+    }
+  }
+});
+
 const boolFalseIfProd = (spec: { default: boolean }) => {
   const is_prod =
     process.env.DEV_IS_LOCAL_ENV !== 'true' &&
@@ -60,7 +77,7 @@ export const get_env = () => {
 
     // Only for configuring CORS for PoC demo purposes, in reality this is expected to be an
     // internal server-to-server API, with no direct frontend access
-    TRANSFER_DASHBOARD_ORIGIN: url({ default: '*' }),
+    TRANSFER_DASHBOARD_ORIGINS: originList({ default: '*' }),
 
     DEV_IS_LOCAL_ENV: boolFalseIfProd({ default: false }),
     DEV_IS_TEST_ENV: boolFalseIfProd({ default: false }),

--- a/transfer-outbound/src/env.ts
+++ b/transfer-outbound/src/env.ts
@@ -58,6 +58,10 @@ export const get_env = () => {
     OWN_TRANSFER_CODE: transferCode(),
     INBOUND_TRANSFER_SERIVCES_BY_TRANSFER_CODE: urlByTransferCode(),
 
+    // Only for configuring CORS for PoC demo purposes, in reality this is expected to be an
+    // internal server-to-server API, with no direct frontend access
+    TRANSFER_DASHBOARD_ORIGIN: url({ default: '*' }),
+
     DEV_IS_LOCAL_ENV: boolFalseIfProd({ default: false }),
     DEV_IS_TEST_ENV: boolFalseIfProd({ default: false }),
   });


### PR DESCRIPTION
Configuring CORS so browsers will accept requests crossing from to the transfer-outbound APIs from either the deployed transfer dashboard OR localhost dev builds. Should unblock your connections @samiatoui.