### PR TITLE
Move demo-transfer-dashboard env vars from run-time mounting to build-time args

### DIFF
--- a/demo-transfer-dashboard/Dockerfile
+++ b/demo-transfer-dashboard/Dockerfile
@@ -8,6 +8,12 @@ COPY package-lock.json /app/package-lock.json
 RUN npm ci
 
 COPY . /app
+
+# These env vars need to exist at build-time, setting them on the container at run-time doesn't change
+# the values in the static content generated here and served when the container is run
+ARG ON_OUTBOUND_URL="https://transfer-outbound.on.iidi.alpha.phac.gc.ca"
+ARG BC_OUTBOUND_URL="https://transfer-outbound.bc.iidi.alpha.phac.gc.ca"
+
 RUN npm run build
 
 # 2. Serve static app via nginx

--- a/k8s/demo-transfer-dashboard/deployment.yaml
+++ b/k8s/demo-transfer-dashboard/deployment.yaml
@@ -19,11 +19,6 @@ spec:
           imagePullPolicy: Always
           ports:
             - containerPort: 3000
-          env:
-            - name: ON_OUTBOUND_URL
-              value: "https://transfer-outbound.on.iidi.alpha.phac.gc.ca"
-            - name: BC_OUTBOUND_URL
-              value: "https://transfer-outbound.bc.iidi.alpha.phac.gc.ca"
           readinessProbe:
             httpGet:
               path: /


### PR DESCRIPTION
Could revisit this pattern later, but this is the quick/necessary fix for now. The build system injects the env var values it has at image build time, generating the static content that is then served at container run time. The static content is set by the time it's serving in the cluster, and setting the env vars there doesn't impact anything.

My bad for not noticing this sooner, I set up the dockerfile for this, and it's a offbeat pattern compared to the rest of the containers we're dealing with.   