### PR TITLE
Synthesizer exemption code fixes

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -366,7 +366,7 @@ services:
       DB_HOST: on-fhir-db
       FHIR_SERVER_ADDRESS: http://localhost:8080/on/fhir # see proxy address via gateway.default.conf
   on-synthesizer: &synthesizer-service
-    image: synthesizer:1.3
+    image: synthesizer:1.4
     tty: ${DOCKER_TTY:-true}
     restart: on-failure # reattempt until successful
     build:

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -366,7 +366,7 @@ services:
       DB_HOST: on-fhir-db
       FHIR_SERVER_ADDRESS: http://localhost:8080/on/fhir # see proxy address via gateway.default.conf
   on-synthesizer: &synthesizer-service
-    image: synthesizer:1.2
+    image: synthesizer:1.3
     tty: ${DOCKER_TTY:-true}
     restart: on-failure # reattempt until successful
     build:

--- a/synthesizer/script.py
+++ b/synthesizer/script.py
@@ -192,7 +192,7 @@ def create_immunization_resource(patient_id, birth_date):
     max_date = datetime.today()
     occurrence_date = random_date(min_date, max_date)
 
-    exemption_reason = random.choice([None, "RELIG", "MED", "PHIL"])
+    exemption_reason = random.choice([None, "RELIG", "MED", "PHILISOP"])
     concurrent_vaccine = random.choice(["Influenza", "COVID-19", None])
 
     return {

--- a/synthesizer/script.py
+++ b/synthesizer/script.py
@@ -193,6 +193,12 @@ def create_immunization_resource(patient_id, birth_date):
     occurrence_date = random_date(min_date, max_date)
 
     exemption_reason = random.choice([None, "RELIG", "MED", "PHILISOP"])
+    exemption_display = {
+        "RELIG": "Religious objection",
+        "MED": "Medical contraindication",
+        "PHILISOP": "Philosophical objection"
+    }.get(exemption_reason, "")
+
     concurrent_vaccine = random.choice(["Influenza", "COVID-19", None])
 
     return {
@@ -228,26 +234,22 @@ def create_immunization_resource(patient_id, birth_date):
             }
         ] if random.choice([True, False]) else None,
         "extension": [
-            {
+            *([{
                 "url": "http://hl7.org/fhir/StructureDefinition/immunization-exemption",
                 "valueCodeableConcept": {
                     "coding": [
                         {
                             "system": "http://terminology.hl7.org/CodeSystem/v3-ActReason",
                             "code": exemption_reason,
-                            "display": random.choice([
-                                "Religious objection",
-                                "Medical contraindication",
-                                "Philosophical objection"
-                            ]) if exemption_reason else None
+                            "display": exemption_display
                         }
                     ]
                 }
-            },
-            {
+            }] if exemption_reason else []),
+            *([{
                 "url": "http://hl7.org/fhir/StructureDefinition/immunization-concurrent-administration",
                 "valueString": concurrent_vaccine
-            },
+            }] if concurrent_vaccine else []),
             {
                 "url": "http://hl7.org/fhir/StructureDefinition/immunization-expiry-date",
                 "valueDate": random_date(datetime(2023, 1, 1), datetime(2025, 12, 31))


### PR DESCRIPTION
Corrected the `"PHIL"` code to `"PHILISOP"` and removed possibility of the exemption being set with a `None` value. Both were being caught and rejected by the inbound transfer spec validation.