### PR TITLE
Add an explicit "rejected" terminal stage to the transfer-outbound worker queue

### DIFF
--- a/transfer-inbound/src/create_app.ts
+++ b/transfer-inbound/src/create_app.ts
@@ -33,7 +33,6 @@ export const create_app = async () => {
 
     const transactionBundle = await set_bundle_type_to_transaction(bundle);
 
-    // TODO might be redundant to write_bundle_to_fhir_api, depends if FHIR servers are configured to validate pre-write
     await assert_bundle_follows_fhir_spec(transactionBundle);
 
     const new_patient_id = await write_bundle_to_fhir_api(transactionBundle);

--- a/transfer-inbound/src/create_app.ts
+++ b/transfer-inbound/src/create_app.ts
@@ -37,7 +37,10 @@ export const create_app = async () => {
 
     const new_patient_id = await write_bundle_to_fhir_api(transactionBundle);
 
-    res.status(200).send({ new_patient_id });
+    res.status(201).send({
+      message: 'Patient bundle accepted by FHIR server',
+      patient: { id: new_patient_id },
+    });
   });
 
   app.get('/inbound-transfer/dry-run', async (req, res) => {
@@ -49,7 +52,10 @@ export const create_app = async () => {
 
     await assert_bundle_follows_fhir_spec(transactionBundle);
 
-    res.status(200).send();
+    res.status(200).send({
+      message:
+        'Dry run successful, provided patient bundle would have been accepted by FHIR server',
+    });
   });
 
   app.use(expressErrorHandler);

--- a/transfer-inbound/src/error_utils.test.ts
+++ b/transfer-inbound/src/error_utils.test.ts
@@ -12,8 +12,9 @@ describe('AppError', () => {
 
     expect(appError).toBeInstanceOf(Error);
     expect(appError).toBeInstanceOf(AppError);
-    expect(appError.message).toBe(message);
     expect(appError.status).toBe(status);
+    expect(appError.message).toContain(message);
+    expect(appError.message).toContain(status.toString());
   });
 });
 

--- a/transfer-inbound/src/error_utils.ts
+++ b/transfer-inbound/src/error_utils.ts
@@ -72,22 +72,6 @@ export const expressErrorHandler = (
 ) => {
   handle_error_logging(err);
 
-  const errorResponse: {
-    error: string;
-    details?: SerializableErrorData;
-  } = {
-    error: err.message,
-  };
-
-  if (err instanceof AppError && err.errorData) {
-    try {
-      JSON.parse(JSON.stringify(err.errorData));
-      errorResponse.details = err.errorData;
-    } catch (e) {
-      console.error('Invalid error data provided:', e);
-    }
-  }
-
   res
     .status(get_status_code(err))
     .json(is_app_error(err) ? err.toJSON() : { error: err.message });

--- a/transfer-inbound/src/error_utils.ts
+++ b/transfer-inbound/src/error_utils.ts
@@ -5,7 +5,27 @@ import { get_env } from './env.ts';
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 type SerializableErrorData = Record<string, any>;
 
+const get_app_error_data = (errorData?: SerializableErrorData) => {
+  if (errorData !== undefined) {
+    try {
+      JSON.parse(JSON.stringify(errorData));
+      return errorData;
+    } catch {
+      console.error(
+        `Invalid error data provided, not JSON serializable. Received: "${errorData}"`,
+      );
+    }
+  }
+};
+const get_app_error_message = (
+  status: number,
+  message: string,
+  errorData?: SerializableErrorData,
+) => {
+  return `Status: "${status}". Message: "${message}". ${get_app_error_data(errorData) !== undefined ? `Error data: ${JSON.stringify(get_app_error_data(errorData))}.` : ''}`;
+};
 export class AppError extends Error {
+  message_raw: string;
   status: number;
   errorData?: SerializableErrorData;
 
@@ -14,11 +34,22 @@ export class AppError extends Error {
     message: string,
     errorData?: SerializableErrorData,
   ) {
-    super(message);
+    super(get_app_error_message(status, message, errorData));
+    this.message_raw = message;
     this.status = status;
-    this.errorData = errorData;
+    this.errorData = get_app_error_data(errorData);
+  }
+
+  toJSON() {
+    return {
+      error: this.message_raw,
+      details: this.errorData,
+    };
   }
 }
+
+const is_app_error = (err: Error | AppError): err is AppError =>
+  'status' in err;
 
 const handle_error_logging = (err: Error | AppError) => {
   const { DEV_IS_TEST_ENV } = get_env();
@@ -31,7 +62,7 @@ const handle_error_logging = (err: Error | AppError) => {
 };
 
 const get_status_code = (err: Error | AppError) =>
-  'status' in err ? err.status : 500;
+  is_app_error(err) ? err.status : 500;
 
 export const expressErrorHandler = (
   err: Error | AppError,
@@ -57,5 +88,7 @@ export const expressErrorHandler = (
     }
   }
 
-  res.status(get_status_code(err)).json(errorResponse);
+  res
+    .status(get_status_code(err))
+    .json(is_app_error(err) ? err.toJSON() : { error: err.message });
 };

--- a/transfer-inbound/src/fhir_utils.test.ts
+++ b/transfer-inbound/src/fhir_utils.test.ts
@@ -191,7 +191,7 @@ describe('handle_response', () => {
     });
 
     await expect(handle_response(mockResponse)).rejects.toThrow(
-      new AppError(500, 'FHIR server responded with status 404'),
+      new AppError(404, 'FHIR server responded with status 404'),
     );
   });
 

--- a/transfer-inbound/src/fhir_utils.test.ts
+++ b/transfer-inbound/src/fhir_utils.test.ts
@@ -40,20 +40,23 @@ describe('assert_bundle_follows_fhir_spec', () => {
   });
 
   it('should throw a validation error if the FHIR bundle is invalid', async () => {
-    const mockResponse = {
-      issue: [
-        {
-          severity: 'error',
-          location: ['bundle.entry'],
-          diagnostics: 'Invalid entry in bundle',
-          details: { text: 'Entry does not follow FHIR spec' },
-        },
-      ],
-    };
+    const mockResponse = new Response(
+      JSON.stringify({
+        issue: [
+          {
+            severity: 'error',
+            location: ['bundle.entry'],
+            diagnostics: 'Invalid entry in bundle',
+            details: { text: 'Entry does not follow FHIR spec' },
+          },
+        ],
+      }),
+      {
+        status: 200,
+      },
+    );
 
-    (fetch as jest.Mock).mockResolvedValueOnce({
-      json: jest.fn().mockResolvedValueOnce(mockResponse),
-    });
+    (fetch as jest.Mock).mockResolvedValueOnce(mockResponse);
 
     // Expecting the function to throw an AppError with status 400
     await expect(assert_bundle_follows_fhir_spec(mockBundle)).rejects.toThrow(
@@ -68,16 +71,17 @@ describe('assert_bundle_follows_fhir_spec', () => {
   });
 
   it('should not throw an error if the FHIR bundle is valid', async () => {
-    const mockResponse = {
-      issue: [],
-    };
+    const mockResponse = new Response(
+      JSON.stringify({
+        issue: [],
+      }),
+      {
+        status: 200,
+      },
+    );
 
     // Mocking fetch to return a valid response
-    (fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: jest.fn().mockResolvedValueOnce(mockResponse),
-    });
+    (fetch as jest.Mock).mockResolvedValueOnce(mockResponse);
 
     // We expect no error to be thrown when the validation is successful
     await expect(
@@ -121,14 +125,18 @@ describe('assert_bundle_follows_fhir_spec', () => {
       ],
     };
 
-    (fetch as jest.Mock).mockResolvedValueOnce({
-      ok: false,
+    const mockResponse = new Response(JSON.stringify(serverErrors), {
       status: 500,
-      json: jest.fn().mockResolvedValueOnce(serverErrors),
     });
 
+    (fetch as jest.Mock).mockResolvedValueOnce(mockResponse);
+
     await expect(assert_bundle_follows_fhir_spec(mockBundle)).rejects.toThrow(
-      new AppError(500, 'FHIR spec validation failed', serverErrors.issue),
+      new AppError(
+        500,
+        'FHIR spec validation encountered a server error',
+        serverErrors.issue,
+      ),
     );
   });
 
@@ -147,20 +155,21 @@ describe('assert_bundle_follows_fhir_spec', () => {
   });
 
   it('should handle validation errors without location or diagnostics', async () => {
-    const mockResponse = {
-      issue: [
-        {
-          severity: 'error',
-          // Deliberately omitting location and diagnostics
-        },
-      ],
-    };
+    const mockResponse = new Response(
+      JSON.stringify({
+        issue: [
+          {
+            severity: 'error',
+            // Deliberately omitting location and diagnostics
+          },
+        ],
+      }),
+      {
+        status: 200,
+      },
+    );
 
-    (fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      status: 200,
-      json: jest.fn().mockResolvedValueOnce(mockResponse),
-    });
+    (fetch as jest.Mock).mockResolvedValueOnce(mockResponse);
 
     await expect(assert_bundle_follows_fhir_spec(mockBundle)).rejects.toThrow(
       new AppError(400, 'FHIR spec validation failed', [

--- a/transfer-inbound/src/fhir_utils.ts
+++ b/transfer-inbound/src/fhir_utils.ts
@@ -56,7 +56,11 @@ export const assert_bundle_follows_fhir_spec = async (bundle: Bundle) => {
       }
     } else {
       const serverErrors = responseBody.issue;
-      throw new AppError(500, 'FHIR spec validation failed', serverErrors);
+      throw new AppError(
+        500,
+        'FHIR spec validation encountered a server error',
+        serverErrors,
+      );
     }
   } catch (error) {
     if (error instanceof AppError) {

--- a/transfer-outbound/src/create_app.ts
+++ b/transfer-outbound/src/create_app.ts
@@ -69,7 +69,7 @@ export const create_app = async () => {
 
     const info = await get_transfer_request_job_info(transfer_request_job);
 
-    res.status(200).type('json').send(info);
+    res.status(202).type('json').send(info);
   });
 
   app.get('/transfer-request/dry-run', async (req, res) => {

--- a/transfer-outbound/src/fhir_utils.ts
+++ b/transfer-outbound/src/fhir_utils.ts
@@ -20,7 +20,7 @@ const is_bundle_resource = (json: unknown): json is Bundle =>
   'resourceType' in json &&
   json?.resourceType === 'Bundle';
 
-const get_error_from_fhir_response = async (response: Response) => {
+export const get_error_from_fhir_response = async (response: Response) => {
   const json = (await response.json().catch(() => null)) as {
     issue?: [{ diagnostics?: string }];
   } | null;

--- a/transfer-outbound/src/transfer_request_queue/transferRequest.d.ts
+++ b/transfer-outbound/src/transfer_request_queue/transferRequest.d.ts
@@ -8,4 +8,5 @@ export interface transferRequest {
   stage: transferStage;
   completed_stages: transferStage[];
   new_patient_id?: string;
+  rejection_reason?: string;
 }

--- a/transfer-outbound/src/transfer_request_queue/transfer_request_utils.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_request_utils.ts
@@ -65,8 +65,14 @@ export const get_transfer_request_job_info = async (
   const { failedReason: failed_reason, finishedOn: finished_on } =
     transfer_request_job;
 
-  const { patient_id, transfer_to, stage, completed_stages, rejection_reason } =
-    transfer_request_job.data;
+  const {
+    patient_id,
+    new_patient_id,
+    transfer_to,
+    stage,
+    completed_stages,
+    rejection_reason,
+  } = transfer_request_job.data;
 
   return {
     job_id: transfer_request_job.id,
@@ -74,6 +80,7 @@ export const get_transfer_request_job_info = async (
     finished_on,
     failed_reason,
     patient_id,
+    new_patient_id,
     transfer_to,
     stage,
     completed_stages,

--- a/transfer-outbound/src/transfer_request_queue/transfer_request_utils.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_request_utils.ts
@@ -65,7 +65,7 @@ export const get_transfer_request_job_info = async (
   const { failedReason: failed_reason, finishedOn: finished_on } =
     transfer_request_job;
 
-  const { patient_id, transfer_to, stage, completed_stages } =
+  const { patient_id, transfer_to, stage, completed_stages, rejection_reason } =
     transfer_request_job.data;
 
   return {
@@ -77,5 +77,6 @@ export const get_transfer_request_job_info = async (
     transfer_to,
     stage,
     completed_stages,
+    rejection_reason,
   };
 };

--- a/transfer-outbound/src/transfer_request_queue/transfer_stage_utils.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_stage_utils.ts
@@ -1,27 +1,33 @@
 export const initial_stage = 'collecting_and_transfering';
 
-export const terminal_stage = 'done';
+export const terminal_stages = ['done', 'rejected'] as const;
+export type terminalStage = (typeof terminal_stages)[number];
 
-export const transfer_stages = [
+const non_terminal_transfer_stages = [
   initial_stage,
   'setting_patient_post_transfer_metadata',
-  terminal_stage,
 ] as const;
+type nonTerminalTransferStage = (typeof non_terminal_transfer_stages)[number];
+
+export const transfer_stages = [
+  ...non_terminal_transfer_stages,
+  ...terminal_stages,
+];
 export type transferStage = (typeof transfer_stages)[number];
 
-const non_terminal_transfer_stages = transfer_stages.filter(
-  (stage) => stage !== terminal_stage,
-);
-type nonTerminalTransferStage = (typeof non_terminal_transfer_stages)[number];
+export const is_non_terminal_stage = (
+  stage: unknown,
+): stage is nonTerminalTransferStage =>
+  non_terminal_transfer_stages.includes(stage as nonTerminalTransferStage);
 
 const next_stage_map: Record<nonTerminalTransferStage, transferStage> = {
   collecting_and_transfering: 'setting_patient_post_transfer_metadata',
-  setting_patient_post_transfer_metadata: terminal_stage,
+  setting_patient_post_transfer_metadata: 'done',
 };
 export const get_next_stage = (
-  current_stage: Exclude<transferStage, typeof terminal_stage>,
+  current_stage: nonTerminalTransferStage,
 ): transferStage => {
-  if (!non_terminal_transfer_stages.includes(current_stage)) {
+  if (!is_non_terminal_stage(current_stage)) {
     throw new Error(
       `Unexpected transfer stage "${current_stage}". Should be in [${non_terminal_transfer_stages.join(', ')}]`,
     );

--- a/transfer-outbound/src/transfer_request_queue/transfer_worker.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_worker.ts
@@ -65,17 +65,20 @@ const work_on_transfer_job = async (job: transferRequestJob) => {
         if (
           typeof json === 'object' &&
           json !== null &&
-          'new_patient_id' in json &&
-          typeof json.new_patient_id === 'string'
+          'patient' in json &&
+          typeof json.patient === 'object' &&
+          json.patient !== null &&
+          'id' in json.patient &&
+          typeof json.patient.id === 'string'
         ) {
           await job.updateData({
             ...job.data,
-            new_patient_id: json.new_patient_id,
+            new_patient_id: json.patient.id,
           });
         } else {
           console.warn(
             `Job ID ${job.id}: (patient "${job.data.patient_id}" to "${job.data.transfer_to}") received` +
-              `an ok response from the inbound system, but did not receive a "new_patient_id" in the response body.` +
+              `an ok response from the inbound system, but did not receive "patient.id" in the response body.` +
               `The transfer process will continue, but the outbound system's reference to the new patient will be incomplete`,
           );
         }

--- a/transfer-outbound/src/transfer_request_queue/transfer_worker.ts
+++ b/transfer-outbound/src/transfer_request_queue/transfer_worker.ts
@@ -18,7 +18,10 @@ import {
 } from './transfer_request_utils.ts';
 import type { transferRequestJob } from './transfer_request_utils.ts';
 
-import { terminal_stage, get_next_stage } from './transfer_stage_utils.ts';
+import {
+  is_non_terminal_stage,
+  get_next_stage,
+} from './transfer_stage_utils.ts';
 
 import type { transferRequest } from './transferRequest.js';
 
@@ -42,9 +45,11 @@ const work_on_transfer_job = async (job: transferRequestJob) => {
   // Could try a more complicated use of BullMQ, either spawning child jobs for each stage or using the flow concept, but both of those
   // add a good bit more complexity than we may need. The biggest trade off of the current approach, AFAIK, is that the stages all share
   // the same "attempts" count, so we can't fine tune the number of retries per-stage. Child jobs/a job flow would enable that
-  while (job.data.stage !== terminal_stage) {
+  while (is_non_terminal_stage(job.data.stage)) {
     // TODO for this and all other logging found here, switch to a good struct log approach. These simple logs are placeholders/for dev
     console.log(`Job ID ${job.id}: starting stage "${job.data.stage}"`);
+
+    let next_stage = get_next_stage(job.data.stage);
 
     if (job.data.stage === 'collecting_and_transfering') {
       const bundle = await get_patient_bundle_for_transfer(job.data.patient_id);
@@ -54,12 +59,9 @@ const work_on_transfer_job = async (job: transferRequestJob) => {
         job.data.transfer_to,
       );
 
-      // TODO handle rejected bundles (validation failed), shouldn't retry, should move to a "rejected" stage (replace `terminal_stage` with
-      // `terminal_stages` for both `done` and `rejected`)
+      const json = await transfer_response.json().catch(() => null);
 
       if (transfer_response.ok) {
-        const json = await transfer_response.json().catch(() => null);
-
         if (
           typeof json === 'object' &&
           json !== null &&
@@ -78,9 +80,26 @@ const work_on_transfer_job = async (job: transferRequestJob) => {
           );
         }
       } else {
-        throw new Error(
-          `Job ID ${job.id}: inbound-transfer service for "${job.data.transfer_to}" responded to patient ID "${job.data.patient_id}" transfer with a "${transfer_response.status}" status`,
-        );
+        const base_error_message =
+          `Job ID ${job.id}: inbound-transfer service for "${job.data.transfer_to}" responded to` +
+          `patient ID "${job.data.patient_id}" transfer with a "${transfer_response.status}" status.`;
+
+        if (typeof json === 'object' && json !== null && 'error' in json) {
+          // Handle validation failure (explicit rejection) with an explicit state rather than letting an error throw,
+          // don't want the queue's failure handling/retry logic hammering the transfer endpoint with known-bad requests
+          const rejection_reason = JSON.stringify(json);
+
+          console.error(base_error_message + '\n' + rejection_reason);
+
+          next_stage = 'rejected';
+
+          await job.updateData({
+            ...job.data,
+            rejection_reason,
+          });
+        } else {
+          throw new Error(base_error_message);
+        }
       }
     } else if (job.data.stage === 'setting_patient_post_transfer_metadata') {
       // NOTE: vital assumption: this end point returns 200 IF AND ONLY IF the bundle was accepted and fully written to the receiving
@@ -93,18 +112,20 @@ const work_on_transfer_job = async (job: transferRequestJob) => {
       );
     }
 
-    const completed_stage = job.data.stage;
+    console.log(
+      `Job ID ${job.id}: completed stage "${job.data.stage}, moving to next stage "${next_stage}"`,
+    );
 
     await job.updateData({
       ...job.data,
       completed_stages: [...job.data.completed_stages, job.data.stage],
-      stage: get_next_stage(job.data.stage),
+      stage: next_stage,
     });
-
-    console.log(`Job ID ${job.id}: completed stage "${completed_stage}"`);
   }
 
-  console.log(`Job ID ${job.id}: all done`);
+  console.log(
+    `Job ID ${job.id}: finished on terminal stage "${job.data.stage}"`,
+  );
 
   return job.data;
 };


### PR DESCRIPTION
When the transfer-inbound server rejects a transfer bundle for validation failure reasons, want the queue to move to an explicit "rejected" state rather than throwing the response as an error. Throwing an error leads to retry attempts, which are pointless when the data itself is invalid.

TODO:
  - [x] add new "rejected" terminal stage, modify terminal stage logic to account for multiple terminal stage values
  - [x] move to the "rejected stage" if the `post_bundle_to_inbound_transfer_service` response is a validation rejection