### PR TITLE
Chore: Burstable Pods + Bug Fix

### DIFF
--- a/k8s/bc/aggregation-server/deployment.yaml
+++ b/k8s/bc/aggregation-server/deployment.yaml
@@ -26,13 +26,6 @@ spec:
           value: "http://hapi-fhir-svc.bc.svc.cluster.local:8080/fhir"
         - name: AGGREGATION_INTERVAL
           value: "60"
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "500m"
-          limits:
-            memory: "1Gi"
-            cpu: "1"
         readinessProbe:
           httpGet:
             path: /health

--- a/k8s/bc/aggregation-server/kustomization.yaml
+++ b/k8s/bc/aggregation-server/kustomization.yaml
@@ -4,3 +4,35 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: aggregator-deployment
+        namespace: bc
+      spec:
+        template:
+          spec:
+            containers:
+              - name: aggregator
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 256Mi
+                  limits:
+                    cpu: 1.5
+                    memory: 2Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: aggregator-deployment
+      namespace: bc

--- a/k8s/bc/bc-transfer/kustomization.yaml
+++ b/k8s/bc/bc-transfer/kustomization.yaml
@@ -6,3 +6,66 @@ resources:
   - transfer-outbound.yaml
   - transfer-inbound-service.yaml
   - transfer-outbound-service.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: transfer-inbound
+        namespace: bc
+      spec:
+        template:
+          spec:
+            containers:
+              - name: transfer-inbound
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 256Mi
+                  limits:
+                    cpu: 1.5
+                    memory: 2Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: transfer-inbound
+      namespace: bc
+
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: transfer-outbound
+        namespace: bc
+      spec:
+        template:
+          spec:
+            containers:
+              - name: transfer-outbound
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 256Mi
+                  limits:
+                    cpu: 1.5
+                    memory: 2Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: transfer-outbound
+      namespace: bc

--- a/k8s/bc/bc-transfer/transfer-outbound.yaml
+++ b/k8s/bc/bc-transfer/transfer-outbound.yaml
@@ -32,7 +32,7 @@ spec:
             - name: OWN_TRANSFER_CODE
               value: "BC"
             - name: INBOUND_TRANSFER_SERIVCES_BY_TRANSFER_CODE
-              value: '{ "ON": "http://transfer-inbound.on.svc.cluster.local:3000" }'
+              value: '{ "ON": "http://transfer-inbound-svc.on.svc.cluster.local:3000" }'
             - name: REDIS_PORT
               value: "6379"
             - name: REDIS_PASSWORD

--- a/k8s/bc/hapi-fhir-server/database.yaml
+++ b/k8s/bc/hapi-fhir-server/database.yaml
@@ -55,7 +55,7 @@ spec:
     annotations:
       proxy.istio.io/config: '{ "holdApplicationUntilProxyStarts": true }'
       sidecar.istio.io/proxyCPU: 50m
-      sidecar.istio.io/proxyMemory: 112Mi
+      sidecar.istio.io/proxyMemory: 56Mi
 
   resources:
     requests:

--- a/k8s/bc/hapi-fhir-server/kustomization.yaml
+++ b/k8s/bc/hapi-fhir-server/kustomization.yaml
@@ -7,3 +7,35 @@ resources:
   - deployment.yaml
   - service.yaml
   # - synthetic-data.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: hapi-fhir-server
+        namespace: bc
+      spec:
+        template:
+          spec:
+            containers:
+              - name: hapi-fhir-server
+                resources:
+                  requests:
+                    cpu: 2
+                    memory: 4Gi
+                  limits:
+                    cpu: 4
+                    memory: 8Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: hapi-fhir-server
+      namespace: bc

--- a/k8s/bc/patient-browser/kustomization.yaml
+++ b/k8s/bc/patient-browser/kustomization.yaml
@@ -5,3 +5,34 @@ resources:
 - deployment.yaml
 - service.yaml
 
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: patient-browser
+        namespace: bc
+      spec:
+        template:
+          spec:
+            containers:
+              - name: patient-browser
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+                  limits:
+                    cpu: 1.5
+                    memory: 2Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: patient-browser
+      namespace: bc

--- a/k8s/bc/redis-server/kustomization.yaml
+++ b/k8s/bc/redis-server/kustomization.yaml
@@ -6,3 +6,35 @@ resources:
   - redis-service.yaml
   - redis-secret.enc.yaml
   - redis-config.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: redis
+        namespace: bc
+      spec:
+        template:
+          spec:
+            containers:
+              - name: redis
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+                  limits:
+                    cpu: 1
+                    memory: 2Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: redis
+      namespace: bc

--- a/k8s/on/aggregation-server/deployment.yaml
+++ b/k8s/on/aggregation-server/deployment.yaml
@@ -26,13 +26,6 @@ spec:
           value: "http://hapi-fhir-svc.on.svc.cluster.local:8080/fhir"
         - name: AGGREGATION_INTERVAL
           value: "60"
-        resources:
-          requests:
-            memory: "256Mi"
-            cpu: "500m"
-          limits:
-            memory: "1Gi"
-            cpu: "1"
         readinessProbe:
           httpGet:
             path: /health

--- a/k8s/on/aggregation-server/kustomization.yaml
+++ b/k8s/on/aggregation-server/kustomization.yaml
@@ -4,3 +4,35 @@ kind: Kustomization
 resources:
   - deployment.yaml
   - service.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: aggregator-deployment
+        namespace: "on"
+      spec:
+        template:
+          spec:
+            containers:
+              - name: aggregator
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 256Mi
+                  limits:
+                    cpu: 1.5
+                    memory: 2Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: aggregator-deployment
+      namespace: "on"

--- a/k8s/on/hapi-fhir-server/kustomization.yaml
+++ b/k8s/on/hapi-fhir-server/kustomization.yaml
@@ -7,3 +7,35 @@ resources:
   - deployment.yaml
   - service.yaml
   # - synthetic-data.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: hapi-fhir-server
+        namespace: "on"
+      spec:
+        template:
+          spec:
+            containers:
+              - name: hapi-fhir-server
+                resources:
+                  requests:
+                    cpu: 2
+                    memory: 4Gi
+                  limits:
+                    cpu: 4
+                    memory: 8Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: hapi-fhir-server
+      namespace: "on"

--- a/k8s/on/on-transfer/kustomization.yaml
+++ b/k8s/on/on-transfer/kustomization.yaml
@@ -6,3 +6,66 @@ resources:
   - transfer-outbound.yaml
   - transfer-inbound-service.yaml
   - transfer-outbound-service.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: transfer-inbound
+        namespace: "on"
+      spec:
+        template:
+          spec:
+            containers:
+              - name: transfer-inbound
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 256Mi
+                  limits:
+                    cpu: 1.5
+                    memory: 2Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: transfer-inbound
+      namespace: "on"
+
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: transfer-outbound
+        namespace: "on"
+      spec:
+        template:
+          spec:
+            containers:
+              - name: transfer-outbound
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 256Mi
+                  limits:
+                    cpu: 1.5
+                    memory: 2Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: transfer-outbound
+      namespace: "on"

--- a/k8s/on/on-transfer/transfer-outbound.yaml
+++ b/k8s/on/on-transfer/transfer-outbound.yaml
@@ -32,7 +32,7 @@ spec:
             - name: OWN_TRANSFER_CODE
               value: "ON"
             - name: INBOUND_TRANSFER_SERIVCES_BY_TRANSFER_CODE
-              value: '{ "BC": "http://transfer-inbound.bc.svc.cluster.local:3000" }'
+              value: '{ "BC": "http://transfer-inbound-svc.bc.svc.cluster.local:3000" }'
             - name: REDIS_PORT
               value: "6379"
             - name: REDIS_PASSWORD

--- a/k8s/on/patient-browser/kustomization.yaml
+++ b/k8s/on/patient-browser/kustomization.yaml
@@ -5,3 +5,34 @@ resources:
 - deployment.yaml
 - service.yaml
 
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: patient-browser
+        namespace: "on"
+      spec:
+        template:
+          spec:
+            containers:
+              - name: patient-browser
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+                  limits:
+                    cpu: 1.5
+                    memory: 2Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: patient-browser
+      namespace: "on"

--- a/k8s/on/redis-server/kustomization.yaml
+++ b/k8s/on/redis-server/kustomization.yaml
@@ -6,3 +6,35 @@ resources:
   - redis-service.yaml
   - redis-secret.enc.yaml
   - redis-config.yaml
+
+patches:
+  - patch: |-
+      apiVersion: apps/v1
+      kind: Deployment
+      metadata:
+        name: redis
+        namespace: "on"
+      spec:
+        template:
+          spec:
+            containers:
+              - name: redis
+                resources:
+                  requests:
+                    cpu: 250m
+                    memory: 512Mi
+                  limits:
+                    cpu: 1
+                    memory: 2Gi
+              - name: istio-proxy
+                image: auto
+                resources:
+                  requests:
+                    cpu: 50m
+                    memory: 56Mi
+                securityContext:
+                  allowPrivilegeEscalation: false
+    target:
+      kind: Deployment
+      name: redis
+      namespace: "on"


### PR DESCRIPTION

## Summary
This update refactors CPU and memory requirements across multiple services to ensure efficient resource utilization while allowing burstable performance. Additionally, it updates service endpoints for `transfer-inbound` configurations in **British Columbia (BC) and Ontario (ON)**.

---

### ✅ Standardized Burstable CPU & Memory Configurations
- **Requests:** `250m CPU`, `512Mi - 4Gi Memory` (based on workload type).
- **Limits:** `1-4 CPU`, `2-8Gi Memory` (allows dynamic scaling).
- **Applies to:**  
  - `aggregator`
  - `transfer-inbound`
  - `transfer-outbound`
  - `hapi-fhir-server`
  - `patient-browser`
  - `redis`

### ✅ `transfer-inbound` Service Updates
- Updated **internal service endpoints** for cross-province connectivity.
- **New Service Mappings:**
  - `transfer-inbound-svc.bc.svc.cluster.local:3000`
  - `transfer-inbound-svc.on.svc.cluster.local:3000`

### ✅ Consistent Istio Proxy Configuration Across All Services
- **Requests:** `50m CPU`, `56Mi Memory`
- **Security Context:** `allowPrivilegeEscalation: false`
- Ensures lightweight footprint while maintaining security.

