### PR TITLE
Codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,8 @@
 {
+  "hostRequirements": {
+    "cpus": 4,
+    "memory": "16gb",
+    "storage": "32gb"
+  },
   "postCreateCommand": "./.devcontainer/setup.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,3 @@
 {
-  "remoteEnv": {
-    "IIDI_NGINX_HOST": "https://${CODESPACE_NAME}-8080"
-  }
+  "postCreateCommand": "./.devcontainer/setup.sh"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "remoteEnv": {
+    "IIDI_NGINX_HOST": "https://${CODESPACE_NAME}-8080"
+  }
+}

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+set -o errexit
+set -o pipefail
+set -o nounset
+
+if [[ -n "${CODESPACE_NAME}" ]]; then
+  export IIDI_NGINX_HOST="https://${CODESPACE_NAME}-8080.app.github.dev"
+else
+  export IIDI_NGINX_HOST="http://localhost:8080"
+fi
+
+# add to .bashrc and .zshrc for codespaces session, to persist in new shells
+echo "export IIDI_NGINX_HOST=\"${IIDI_NGINX_HOST}\"" >> ~/.bashrc
+echo "export IIDI_NGINX_HOST=\"${IIDI_NGINX_HOST}\"" >> ~/.zshrc
+
+npm run ci:all

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ Before setting up the development environment, ensure the following dependencies
 
 ## Development quickstart
 
-### Prerequisites
+### Local Machine
+
+#### Local Prerequisites
 
 - Docker v27 (older versions may be sufficient, unverified)
 - Optional:
@@ -109,7 +111,7 @@ Before setting up the development environment, ensure the following dependencies
   - VSCode
     - not strictly required, other editors could be used, but assumed in future steps
 
-### Quickstart Steps
+#### Local Quickstart Steps
 
 - Clone repository locally
 - Open a terminal inside the repo root
@@ -120,7 +122,39 @@ Before setting up the development environment, ensure the following dependencies
 - Wait for docker-compose services to finish spinning up
 - Visit http://localhost:8080 for the "demo portal", which links through to the available services
 
-### IMPORTANT: working with the local docker-compose env
+#### Local Node Service Debugging
+
+- (Re)start the docker-compose environment with `npm run dev:debug`
+- Open `chrome://inspect/#devices` in chrome, click "Open dedicated DevTools for Node" and use the "Add connection" menu to set ports to watch
+  - One per node server in the docker-compose env, should all be exposed as `127.0.0.1:92##`. Look in `./docker-compose.dev.yaml` for containers with port mappings like `9229:92##` to see what services expose debugger sockets
+
+### GitHub Codespaces
+
+#### Codespaces Prerequisites
+
+- Credits to burn
+  - We don't currently have employer provided credits. You likely have a personal amount of 120 free core-hours per month. These may burn faster than you'd think though, the codespace currently needs at least 4 cores to perform. Not ideal.
+
+#### Codespaces Quickstart Steps
+
+- Create a codespace attached to the `iidi-tech` repo
+- Note that `npm run ci:all` runs as a post startup step, don't have to do it manually but packages may not be available immediately on fresh codespace launch
+- (Optional) install recommended vscode exstensions (see `.vscode/extensions.json`); codespaces will prompt you for this
+- Start the local dev docker-compose environment with `npm run dev` from the repo root (default working dir when you open a terminal in the codespace)
+- Wait for docker-compose services to finish spinning up
+- Under the ports tab, find the external URL associated with the codespaces 8080 port. Open this port and you should see the "demo portal" page, which links through to the available services
+
+#### Codespaces Node Service Debugging
+
+- (Re)start the docker-compose environment with `npm run dev:debug`
+- On your local machine, install the GitHub CLI "gh", run `gh auth login` and `gh auth refresh -h github.com -s codespace`, follow interactive steps
+- Use the GitHub CLI ssh tool to create an SSH tunnel from your local machine to the codespace container, eg. `gh codespace ssh -- -L 92##:localhost:92## -L 92##:localhost:92##...`
+  - One per node server in the docker-compose env, should all be exposed an ports `92##`. Look in `./docker-compose.dev.yaml` for containers with port mappings like `9229:92##` to see what services expose debuggers
+  - Note: might be rejected if you try to make too many tunnels, uncertain. If it does, only tunnel to the specific debug port(s) you need
+- Open `chrome://inspect/#devices` in chrome, click "Open dedicated DevTools for Node" and use the "Add connection" menu to set ports to watch
+  - One per SSH tunnel, should all be exposed as `127.0.0.1:92##`
+
+### IMPORTANT: working with the dev docker-compose env
 
 It's important to note that the local docker images are cached by the `name:tag` pair set in each docker-compose service's `image` field. Images that copy in code/dependnecies at image build time need to have their tag incremented in the docker-compose file to ensure that up to date changes are captured! This is both a problem in dev (to refresh against local changes, you need to either increment the tag number or run `docker image rm name:tag --force` and then restart the docker-compose env) and for commited code between devs (assume other devs have cached builds of older version numbers, if you merge changes without bumping the tag then your changes may not be reflected in their local dev env).
 

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -406,10 +406,11 @@ services:
       FHIR_SERVER_ADDRESS: '${IIDI_NGINX_HOST:-http://localhost:8080}/on/fhir' # see proxy address via gateway.default.conf
   on-synthesizer: &synthesizer-service
     image: synthesizer:1.4
-    tty: ${DOCKER_TTY:-true}
-    restart: on-failure # reattempt until successful
+    pull_policy: never # this is a named local image, disable docker default attempt to pull from a remote
     build:
       context: ./synthesizer
+    tty: ${DOCKER_TTY:-true}
+    restart: on-failure # reattempt until successful
     networks:
       - on-internal
     environment:
@@ -418,10 +419,11 @@ services:
       FHIR_URL: http://on-fhir:8080/fhir # in this case, resolved inside the container, with container networking
   on-aggregator: &aggregator-service
     image: aggregator:1.10
-    tty: ${DOCKER_TTY:-true}
-    restart: always
+    pull_policy: never # this is a named local image, disable docker default attempt to pull from a remote
     build:
       context: ./aggregator
+    tty: ${DOCKER_TTY:-true}
+    restart: always
     configs:
       - source: dev-public-key.conf
         target: /dev-secrets/public_key.pem
@@ -437,10 +439,11 @@ services:
       PUBLIC_KEY_PATH: /dev-secrets/public_key.pem
   on-patient-browser: &patient-browser-service
     image: patient-browser:1.1
-    tty: ${DOCKER_TTY:-true}
-    restart: always
+    pull_policy: never # this is a named local image, disable docker default attempt to pull from a remote
     build:
       context: ./patient-browser
+    tty: ${DOCKER_TTY:-true}
+    restart: always
     networks:
       - gateway
       - on-internal
@@ -450,11 +453,12 @@ services:
       FHIR_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/on/fhir/' # in this case, resolved in the host browser, not container networking, see gateway.default.conf
   on-transfer-inbound: &transfer-inbound-service
     image: node-dev:1.0
-    tty: ${DOCKER_TTY:-true}
-    restart: always
+    pull_policy: never # this is a named local image, disable docker default attempt to pull from a remote
     build:
       context: ./node-dev-docker-env
       dockerfile: ./Dockerfile.node-dev
+    tty: ${DOCKER_TTY:-true}
+    restart: always
     volumes:
       - ./transfer-inbound:/home/node-dev/project
       - ./transfer-inbound/.env.node-dev-docker-env-overrides:/home/node-dev/project/.env
@@ -486,11 +490,12 @@ services:
       REDIS_PASSWORD: local-dev-value
   on-transfer-outbound: &transfer-outbound-service
     image: node-dev:1.0
-    tty: ${DOCKER_TTY:-true}
-    restart: always
+    pull_policy: never # this is a named local image, disable docker default attempt to pull from a remote
     build:
       context: ./node-dev-docker-env
       dockerfile: ./Dockerfile.node-dev
+    tty: ${DOCKER_TTY:-true}
+    restart: always
     volumes:
       - ./transfer-outbound:/home/node-dev/project
       - ./transfer-outbound/.env.node-dev-docker-env-overrides:/home/node-dev/project/.env
@@ -598,11 +603,12 @@ services:
 
   federator:
     image: node-dev:1.0
-    tty: ${DOCKER_TTY:-true}
-    restart: always
+    pull_policy: never # this is a named local image, disable docker default attempt to pull from a remote
     build:
       context: ./node-dev-docker-env
       dockerfile: ./Dockerfile.node-dev
+    tty: ${DOCKER_TTY:-true}
+    restart: always
     volumes:
       - ./federator:/home/node-dev/project
       - ./federator/.env.node-dev-docker-env-overrides:/home/node-dev/project/.env
@@ -626,10 +632,11 @@ services:
       PRIVATE_KEY_PATH: '/dev-secrets/private_key.pem'
   dashboard:
     image: rshiny-dashboard:1.0
-    tty: ${DOCKER_TTY:-true}
-    restart: always
+    pull_policy: never # this is a named local image, disable docker default attempt to pull from a remote
     build:
       context: ./rshiny-dashboard
+    tty: ${DOCKER_TTY:-true}
+    restart: always
     networks:
       - gateway
       - federal-internal
@@ -640,9 +647,10 @@ services:
 
   demo-portal:
     image: demo-portal:1.5
-    tty: ${DOCKER_TTY:-true}
+    pull_policy: never # this is a named local image, disable docker default attempt to pull from a remote
     build:
       context: ./demo-portal
+    tty: ${DOCKER_TTY:-true}
     networks:
       - gateway
     ports:
@@ -660,11 +668,12 @@ services:
       ON_DEMO_TRANSFER_DASHBOARD_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/demo-transfer-dashboard?pt=ON'
   demo-transfer-dashboard:
     image: node-dev:1.0
-    tty: ${DOCKER_TTY:-true}
-    restart: always
+    pull_policy: never # this is a named local image, disable docker default attempt to pull from a remote
     build:
       context: ./node-dev-docker-env
       dockerfile: ./Dockerfile.node-dev
+    tty: ${DOCKER_TTY:-true}
+    restart: always
     volumes:
       - ./demo-transfer-dashboard:/home/node-dev/project
       - ./demo-transfer-dashboard/.env.node-dev-docker-env-overrides:/home/node-dev/project/.env

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 # good to specify the project name for a more consistent resulting environment. For example, network names
 # are prefixed by the compose file's project name https://docs.docker.com/compose/how-tos/networking/
 name: iidi

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -405,7 +405,7 @@ services:
       <<: *fhir-db-env
       DB_PORT: 5432
       DB_HOST: on-fhir-db
-      FHIR_SERVER_ADDRESS: http://localhost:8080/on/fhir # see proxy address via gateway.default.conf
+      FHIR_SERVER_ADDRESS: '${IIDI_NGINX_HOST:-http://localhost:8080}/on/fhir' # see proxy address via gateway.default.conf
   on-synthesizer: &synthesizer-service
     image: synthesizer:1.4
     tty: ${DOCKER_TTY:-true}
@@ -449,7 +449,7 @@ services:
     ports:
       - 80:80
     environment:
-      FHIR_URL: http://localhost:8080/on/fhir/ # in this case, resolved in the host browser, not container networking, see gateway.default.conf
+      FHIR_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/on/fhir/' # in this case, resolved in the host browser, not container networking, see gateway.default.conf
   on-transfer-inbound: &transfer-inbound-service
     image: node-dev:1.0
     tty: ${DOCKER_TTY:-true}
@@ -532,7 +532,7 @@ services:
       <<: *fhir-db-env
       DB_PORT: 5432
       DB_HOST: bc-fhir-db
-      FHIR_SERVER_ADDRESS: http://localhost:8080/bc/fhir # see proxy address via gateway.default.conf
+      FHIR_SERVER_ADDRESS: '${IIDI_NGINX_HOST:-http://localhost:8080}/bc/fhir' # see proxy address via gateway.default.conf
   bc-synthesizer:
     <<: *synthesizer-service
     networks:
@@ -557,7 +557,7 @@ services:
       - gateway
       - bc-internal
     environment:
-      FHIR_URL: http://localhost:8080/bc/fhir/ # in this case, resolved in the host browser, not container networking, see gateway.default.conf
+      FHIR_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/bc/fhir/' # in this case, resolved in the host browser, not container networking, see gateway.default.conf
   bc-transfer-inbound:
     <<: *transfer-inbound-service
     command: npm run dev # note: only opening debug ports on the ON services
@@ -650,16 +650,16 @@ services:
     ports:
       - 8080:8080
     environment:
-      FED_DASHBOARD_URL: http://localhost:8080/fed/dashboard
-      FED_FEDERATOR_URL: http://localhost:8080/fed/federator/aggregated-data
-      BC_BROWSER_URL: http://localhost:8080/bc/browser
-      BC_FHIR_URL: http://localhost:8080/bc/fhir
-      BC_AGGREGATOR_URL: http://localhost:8080/bc/aggregator/aggregated-data
-      BC_DEMO_TRANSFER_DASHBOARD_URL: http://localhost:8080/demo-transfer-dashboard?pt=BC
-      ON_BROWSER_URL: http://localhost:8080/on/browser
-      ON_FHIR_URL: http://localhost:8080/on/fhir
-      ON_AGGREGATOR_URL: http://localhost:8080/on/aggregator/aggregated-data
-      ON_DEMO_TRANSFER_DASHBOARD_URL: http://localhost:8080/demo-transfer-dashboard?pt=ON
+      FED_DASHBOARD_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/fed/dashboard'
+      FED_FEDERATOR_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/fed/federator/aggregated-data'
+      BC_BROWSER_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/bc/browser'
+      BC_FHIR_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/bc/fhir'
+      BC_AGGREGATOR_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/bc/aggregator/aggregated-data'
+      BC_DEMO_TRANSFER_DASHBOARD_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/demo-transfer-dashboard?pt=BC'
+      ON_BROWSER_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/on/browser'
+      ON_FHIR_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/on/fhir'
+      ON_AGGREGATOR_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/on/aggregator/aggregated-data'
+      ON_DEMO_TRANSFER_DASHBOARD_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/demo-transfer-dashboard?pt=ON'
   demo-transfer-dashboard:
     image: node-dev:1.0
     tty: ${DOCKER_TTY:-true}
@@ -686,5 +686,5 @@ services:
       PORT: 3005
       BASE_PATH: /demo-transfer-dashboard # see docker-compose nginx config, the rsbuild is behind a proxy path, needs to be configured to serve relative to it
       # the demo transfer dashboard will make transfer-outbound API request from the browser, so request must go through the nginx gateway paths
-      ON_OUTBOUND_URL: http://localhost:8080/on/outbound
-      BC_OUTBOUND_URL: http://localhost:8080/bc/outbound
+      ON_OUTBOUND_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/on/outbound'
+      BC_OUTBOUND_URL: '${IIDI_NGINX_HOST:-http://localhost:8080}/bc/outbound'

--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -360,6 +360,7 @@ services:
     configs:
       - source: gateway.default.conf
         target: /etc/nginx/conf.d/default.conf
+        mode: 0444 # this is the default value, making explicit as something in codespaces seems to overide it
     networks:
       - gateway
       - host-loopback
@@ -397,6 +398,7 @@ services:
     configs:
       - source: hapi
         target: /app/config/application.yaml
+        mode: 0444 # this is the default value, making explicit as something in codespaces seems to overide it
     environment:
       # NOTE: the env vars below are interpolated in to the hapi application.yaml at run time
       # If you add any env vars for other purposes, put them above this comment, to keep track of things
@@ -427,6 +429,7 @@ services:
     configs:
       - source: dev-public-key.conf
         target: /dev-secrets/public_key.pem
+        mode: 0444 # this is the default value, making explicit as something in codespaces seems to overide it
     networks:
       - gateway
       - on-internal
@@ -615,6 +618,7 @@ services:
     configs:
       - source: dev-private-key.conf
         target: /dev-secrets/private_key.pem
+        mode: 0444 # this is the default value, making explicit as something in codespaces seems to overide it
     command: npm run dev:${DOCKER_API_COMMAND:-docker} # 'docker' or 'docker-debug'
     networks:
       - gateway


### PR DESCRIPTION
Closes #215

TODO:
  - [x] set all docker compose url env vars with instance-appropriate nginx gateway urls 
  - [x] ~fix apparent docker networking issues inside codespaces~ 
    - fixed itself somewhere in the process of other minor cleanup I performed and/giving the codespace more resources
    - this apparent issue was most visible in the synthesizers failing to communicate with the FHIR server, might have just been the FHIR servers/their required DBs choking on low resources and never getting ready, rather than a container networking problem 
  - [x] figure out why federator secret key isn't mounting
  - [x] make sure that port forwarding works for the node debug ports 
    - can be done be making an SSH tunnel from your local machine as needed, via `gh codespace ssh -- -L <debug port in coespace>:localhost:<local port>`. 
  - [x] docs, including node debugger access via SSH tunnel
  
Optional/follow up:
  - [ ] various startup time optimizations I could make (customizing and prebuilding the codespaces container, caching dev docker compose images in GCP maybe, etc)
  - [ ] test burn rate on free monthly CPU hours, might be a problem