### PR TITLE
GitHub app for ArgoCD-GitHub auth

### DIFF
--- a/k8s/argocd-notifications/github-auth-app-secrets.yaml
+++ b/k8s/argocd-notifications/github-auth-app-secrets.yaml
@@ -1,0 +1,23 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: github-auth-app-secrets
+  namespace: argocd
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: github-auth-app-secrets
+    creationPolicy: Owner
+  data:
+  - secretKey: githubAppID
+    remoteRef:
+      key: /argocd-github-auth-app-secrets/app-id
+  - secretKey: githubAppInstallationID
+    remoteRef:
+      key: /argocd-github-auth-app-secrets/app-installation-id
+  - secretKey: githubAppPrivateKey
+    remoteRef:
+      key: /argocd-github-auth-app-secrets/app-private-key

--- a/k8s/argocd-notifications/kustomization.yaml
+++ b/k8s/argocd-notifications/kustomization.yaml
@@ -1,0 +1,6 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - ./github-auth-app-secrets.yaml
+  - ./notifications-cm.yaml

--- a/k8s/argocd-notifications/notifications-cm.yaml
+++ b/k8s/argocd-notifications/notifications-cm.yaml
@@ -102,3 +102,16 @@ data:
         state: success
         label: "argo-cd/{{.app.metadata.name}}"
         targetURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+
+  # default subscriptions, applied to all application resources
+  # I believe `github: ""` under recipients will cause the `repoURL` of the given application resource to be used
+  subscriptions: |
+    - recipients:
+      - github: "" 
+      triggers:
+      - on-health-degraded
+      - on-sync-failed
+      - on-deployed
+      - on-sync-running
+      - on-sync-status-unknown
+      - on-sync-succeeded

--- a/k8s/argocd-notifications/notifications-cm.yaml
+++ b/k8s/argocd-notifications/notifications-cm.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argocd-notifications-cm
+  namespace: argocd
+data:
+  service.github: |
+    appID: $githubAppID
+    installationID: $githubAppInstallationID
+    privateKey: $githubAppPrivateKey
+
+  # triggers from https://github.com/argoproj/argo-cd/blob/fff55f23f11f7bdeea77ba3d776c56b9db1f0bd9/notifications_catalog/install.yaml
+  # templates original
+  trigger.on-deployed: |
+    - description: Application is synced and healthy. Triggered once per commit.
+      oncePer: app.status.operationState?.syncResult?.revision
+      send:
+        - app-deployed
+      when: app.status.operationState != nil and app.status.operationState.phase in ['Succeeded']
+        and app.status.health.status == 'Healthy' and (!time.Parse(app.status.health.lastTransitionTime).Add(1
+        * time.Minute).Before(time.Parse(app.status.operationState.finishedAt)) or time.Parse(app.status.health.lastTransitionTime).Before(time.Parse(app.status.operationState.startedAt)))
+  template.app-deployed: |
+    - message: |
+      Application {{.app.metadata.name}} is synced and healthy.
+    - github:
+      status:
+        state: success
+        label: "argo-cd/{{.app.metadata.name}}"
+        targetURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+
+  trigger.on-health-degraded: |
+    - description: Application has degraded
+      oncePer: app.status.operationState?.syncResult?.revision
+      send:
+        - app-health-degraded
+      when: app.status.health.status == 'Degraded'
+  template.app-health-degraded: |
+    - message: |
+      Application {{.app.metadata.name}} is degraded.
+    - github:
+      status:
+        state: failure
+        label: "argo-cd/{{.app.metadata.name}}"
+        targetURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+  
+  trigger.on-sync-failed: |
+    - description: Application syncing has failed
+      oncePer: app.status.operationState?.syncResult?.revision
+      send:
+        - app-sync-failed
+      when: app.status.operationState != nil and app.status.operationState.phase in ['Error',Failed']
+  template.app-sync-failed: |
+    - message: |
+      Application {{.app.metadata.name}} syncing has failed.
+    - github:
+      status:
+        state: failure
+        label: "argo-cd/{{.app.metadata.name}}"
+        targetURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+  
+  trigger.on-sync-running: |
+    - description: Application is being synced
+      oncePer: app.status.operationState?.syncResult?.revision
+      send:
+        - app-sync-running
+      when: app.status.operationState != nil and app.status.operationState.phase in ['Running']
+  template.app-sync-running: |
+    - message: |
+      Application {{.app.metadata.name}} is being synced.
+    - github:
+      status:
+        state: in_progress
+        label: "argo-cd/{{.app.metadata.name}}"
+        targetURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+
+  trigger.on-sync-status-unknown: |
+    - description: Application status is 'Unknown'
+      oncePer: app.status.operationState?.syncResult?.revision
+      send:
+        - app-sync-status-unknown
+      when: app.status.sync.status == 'Unknown'
+  template.app-sync-status-unknown: |
+    - message: |
+      Application {{.app.metadata.name}} is currently unknown.
+    - github:
+      status:
+        state: failure
+        label: "argo-cd/{{.app.metadata.name}}"
+        targetURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"
+  
+  trigger.on-sync-succeeded: |
+    - description: Application syncing has succeeded
+      oncePer: app.status.operationState?.syncResult?.revision
+      send:
+        - app-sync-succeeded
+      when: app.status.operationState != nil and app.status.operationState.phase in ['Succeeded']
+  template.app-sync-succeeded: |
+    - message: |
+      Application {{.app.metadata.name}} has synced successfully.
+    - github:
+      status:
+        state: success
+        label: "argo-cd/{{.app.metadata.name}}"
+        targetURL: "{{.context.argocdUrl}}/applications/{{.app.metadata.name}}?operation=true"


### PR DESCRIPTION
TODO:
  - [x] create a GitHub app with read/write permissions on commit status and repo content
    - commit status for ArgoCD status notifications (application sync state, health)
    - repo content for image updater commits
  - [x] install the app on `PHACDataHub/iidi-tech`, save the app ID, installation ID, and private key in google secret manager
  - [x] create external secrets resource for GitHub app secrets
    - just the manifest for now, haven't manually applied any k8s changes from this branch yet
  - [x] create and populate configmap manifest for `argocd-notifications-cm`
    - as a test for now, if the GitHub app works for that, we can follow up to use it for the image updater as well
    
Possible optional items/follow up, for discussion:
  - [ ] move `k8s/applications`, `k8s/image-updater` and `k8s/argocd-notifications` under a new `k8s/argocd` directory
    - IIRC, our manifest organization pattern is to use a directory structure reflecting namespaces, right? Otherwise, I'd say maybe append `argocd-` as a prefix to `applications` and `image-updater`, to give the directory names context and grouping at a glance... but there's going to be more argo manifests and shared resources like the GitHub app secrets, so a directory makes more sense IMO
  - [ ] I may be missing something, but at the moment the cluster state (specifically the ArgoCD components) aren't reflected in the repo manifests. I assume it was installed in the cluster via a CLI tool, and maybe I'm missing something about the recommended ArgoCD bootstrapping process, but I'd think it'd be preferable to reflect it's state and configuration in the repo's manifests, for portability/redeployment?