### PR TITLE
Use GitHub app credentials for image update auth

### DIFF
--- a/federator/src/create_app.ts
+++ b/federator/src/create_app.ts
@@ -17,7 +17,7 @@ const get_private_key = _.memoize((private_key_path) =>
 export const create_app = async () => {
   const app = express();
 
-  // we'll need to be able to read `X-Forwarded-*` headers, both in prod and when using the dev docker setup
+  // We'll need to be able to read `X-Forwarded-*` headers, both in prod and when using the dev docker setup
   app.set('trust proxy', true);
 
   app.use(express.json()); // parses JSON body payloads, converts req.body from a string to object

--- a/k8s/argocd/image-updater/git-creds.yaml
+++ b/k8s/argocd/image-updater/git-creds.yaml
@@ -1,0 +1,24 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: git-creds
+  namespace: argocd
+spec:
+  refreshInterval: 1h
+  secretStoreRef:
+    name: gcp-secret-store
+    kind: ClusterSecretStore
+  target:
+    name: git-creds
+    creationPolicy: Owner
+  # same data as argocd-notifiactions-secret
+  data:
+  - secretKey: githubAppID
+    remoteRef:
+      key: argocd-github-auth-app-id
+  - secretKey: githubAppInstallationID
+    remoteRef:
+      key: argocd-github-auth-app-installation-id
+  - secretKey: githubAppPrivateKey
+    remoteRef:
+      key: argocd-github-auth-app-private-key


### PR DESCRIPTION
Had two options, either replace the contents of the `argocd/git-creds` secret with the GitHub app values (same content as `argocd-notifications-secret`), or update all application manifests to replace
```
argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/git-creds
```
with
```
argocd-image-updater.argoproj.io/write-back-method: git:secret:argocd/argocd-notifications-secret
```

Went with the `argocd/git-creds` approach since there's always the possibility that the creds used for GitHub status notifications and image updater write-backs could diverge at some point (e.g. if we want to bother creating a distinct GitHub app for each).