### PR TITLE
fix (transfer-inbound) : removed meta.source from bundle to fix FHIR validation failure

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -479,6 +479,20 @@ services:
       EXPRESS_PORT: 3000
       DEV_IS_LOCAL_ENV: True
       FHIR_URL: http://on-fhir:8080/fhir # in this case, resolved inside the container, with container networking
+    develop:
+      watch:
+        # Sync code changes then restart the service
+        - action: sync+restart
+          path: ./transfer-inbound
+          target: /home/node-dev/project
+          ignore:
+            - node_modules/
+            - .env.node-dev-docker-env-overrides
+        # Rebuild if Dockerfile or dependencies change
+        - action: rebuild
+          path: node-dev-docker-env/Dockerfile.node-dev
+        - action: rebuild
+          path: node-dev-docker-env/package.json
   on-bullmq-redis: &bullmq-redis
     image: redis:7.4.1-alpine
     tty: ${DOCKER_TTY:-true}


### PR DESCRIPTION
Sample Issue : 
"rejection_reason": "Job ID 4: inbound-transfer service for \"ON\" responded to patient ID \"6094\" transfer with a \"400\" status.{\"error\":\"FHIR spec validation failed\",\"details\":[{\"location\":\"Bundle.entry[0].resource/*Patient/6094*/.meta.source, Line[1] Col[204]\",\"diagnostics\":\"URL value '#86d75961-8a0f-42' does not resolve\",\"details\":\"No details provided\"},{\"location\":\"Bundle.entry[1].resource/*AllergyIntolerance/6095*/.meta.source, Line[1] Col[1269]\",\"diagnostics\":\"URL value '#86d75961-8a0f-42' does not resolve\",\"details\":\"No details provided\"},{\"location\":\"Bundle.entry[2].resource/*Immunization/6096*/.meta.source, Line[1] Col[2022]\",\"diagnostics\":\"URL value '#86d75961-8a0f-42' does not resolve\",\"details\":\"No details provided\"}]}"

Explanation :
The HAPI FHIR server attaches a meta object to each resource which contains information about the resource, such as its version, last updated time, and source.
The source field is pre-populated by the HAPI FHIR server with a URL value of the source
However, in our case the server sets a random value which does not comply with the URL format (Reason: TODO). 
HAPI FHIR Docker image v8.2.0-1 onwards $validate calls to the FHIR server throw an error if the source field is not in the correct format. 
Simply removing the source field from the resources seems to be resolving the issue.
